### PR TITLE
Fix PDF filename validation regex

### DIFF
--- a/Components/Pages/PdfBrowser.razor
+++ b/Components/Pages/PdfBrowser.razor
@@ -1,6 +1,7 @@
 @page "/pdfs"
 @using System.Net.Http.Json
 @inject HttpClient Http
+@inject NavigationManager Navigation
 
 <h2 class="mb-3">📄 PDF Browser (Local Server)</h2>
 
@@ -60,7 +61,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        files = await Http.GetFromJsonAsync<List<PdfInfo>>("/api/pdfs");
+        var endpoint = Navigation.ToAbsoluteUri("/api/pdfs");
+        files = await Http.GetFromJsonAsync<List<PdfInfo>>(endpoint);
         selected = files?.FirstOrDefault()?.name;
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -6,6 +6,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
+builder.Services.AddHttpClient();
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
@@ -25,7 +27,7 @@ Directory.CreateDirectory(pdfRoot);
 
 // กัน path traversal + บังคับ .pdf
 bool IsSafeFileName(string name) =>
-    Regex.IsMatch(name, @"^[\\w\\-. ]+\\.pdf$", RegexOptions.IgnoreCase);
+    Regex.IsMatch(name, @"^[\\w. -]+\\.pdf$", RegexOptions.IgnoreCase);
 
 // 1) รายการไฟล์
 app.MapGet("/api/pdfs", () =>


### PR DESCRIPTION
## Summary
- correct the PDF filename validation pattern to avoid invalid character range errors

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df559231cc832f8887a085f5fe4fc0