### PR TITLE
Relax PDF filename validation

### DIFF
--- a/Components/Pages/PdfBrowser.razor
+++ b/Components/Pages/PdfBrowser.razor
@@ -1,6 +1,7 @@
 @page "/pdfs"
 @using System.Net.Http.Json
 @inject HttpClient Http
+@inject NavigationManager Navigation
 
 <h2 class="mb-3">📄 PDF Browser (Local Server)</h2>
 
@@ -60,7 +61,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        files = await Http.GetFromJsonAsync<List<PdfInfo>>("/api/pdfs");
+        var endpoint = Navigation.ToAbsoluteUri("/api/pdfs");
+        files = await Http.GetFromJsonAsync<List<PdfInfo>>(endpoint);
         selected = files?.FirstOrDefault()?.name;
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,10 @@
-using System.Text.RegularExpressions;
-
 var builder = WebApplication.CreateBuilder(args);
 
 // เปิดโหมด Blazor Server
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 
@@ -24,8 +24,20 @@ var pdfRoot = app.Configuration["PdfStorage:Root"]
 Directory.CreateDirectory(pdfRoot);
 
 // กัน path traversal + บังคับ .pdf
-bool IsSafeFileName(string name) =>
-    Regex.IsMatch(name, @"^[\\w\\-. ]+\\.pdf$", RegexOptions.IgnoreCase);
+bool IsSafeFileName(string name)
+{
+    if (!name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    if (!string.Equals(Path.GetFileName(name), name, StringComparison.Ordinal))
+    {
+        return false;
+    }
+
+    return name.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+}
 
 // 1) รายการไฟล์
 app.MapGet("/api/pdfs", () =>


### PR DESCRIPTION
## Summary
- replace the regex-based PDF filename validation with path and invalid-character checks so legitimate filenames are accepted while still blocking traversal attempts

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df559231cc832f8887a085f5fe4fc0