### PR TITLE
Serve PDFs inline with dedicated download endpoint

### DIFF
--- a/Components/Pages/PdfBrowser.razor
+++ b/Components/Pages/PdfBrowser.razor
@@ -1,6 +1,7 @@
 @page "/pdfs"
 @using System.Net.Http.Json
 @inject HttpClient Http
+@inject NavigationManager Navigation
 
 <h2 class="mb-3">📄 PDF Browser (Local Server)</h2>
 
@@ -23,7 +24,7 @@
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         <button class="btn btn-link p-0" @onclick="() => Select(f.name)">@f.name</button>
                         <a class="btn btn-sm btn-outline-secondary"
-                           href="@($"/api/pdfs/{Uri.EscapeDataString(f.name)}")" target="_blank">ดาวน์โหลด</a>
+                           href="@($"/api/pdfs/{Uri.EscapeDataString(f.name)}/download")" target="_blank">ดาวน์โหลด</a>
                     </li>
                 }
             }
@@ -60,7 +61,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        files = await Http.GetFromJsonAsync<List<PdfInfo>>("/api/pdfs");
+        var endpoint = Navigation.ToAbsoluteUri("/api/pdfs");
+        files = await Http.GetFromJsonAsync<List<PdfInfo>>(endpoint);
         selected = files?.FirstOrDefault()?.name;
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,10 @@
-using System.Text.RegularExpressions;
-
 var builder = WebApplication.CreateBuilder(args);
 
 // เปิดโหมด Blazor Server
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 
@@ -24,8 +24,20 @@ var pdfRoot = app.Configuration["PdfStorage:Root"]
 Directory.CreateDirectory(pdfRoot);
 
 // กัน path traversal + บังคับ .pdf
-bool IsSafeFileName(string name) =>
-    Regex.IsMatch(name, @"^[\\w\\-. ]+\\.pdf$", RegexOptions.IgnoreCase);
+bool IsSafeFileName(string name)
+{
+    if (!name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    if (!string.Equals(Path.GetFileName(name), name, StringComparison.Ordinal))
+    {
+        return false;
+    }
+
+    return name.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+}
 
 // 1) รายการไฟล์
 app.MapGet("/api/pdfs", () =>
@@ -41,12 +53,42 @@ app.MapGet("/api/pdfs", () =>
     return Results.Ok(files);
 });
 
-// 2) พรีวิว/ดาวน์โหลด
+IResult? ValidatePdfRequest(string name, out string fullPath)
+{
+    fullPath = string.Empty;
+    if (!IsSafeFileName(name))
+    {
+        return Results.BadRequest("invalid file name");
+    }
+
+    var candidate = Path.Combine(pdfRoot, name);
+    if (!System.IO.File.Exists(candidate))
+    {
+        return Results.NotFound();
+    }
+
+    fullPath = candidate;
+    return null;
+}
+
+// 2) พรีวิว inline
 app.MapGet("/api/pdfs/{name}", (string name) =>
 {
-    if (!IsSafeFileName(name)) return Results.BadRequest("invalid file name");
-    var fullPath = Path.Combine(pdfRoot, name);
-    if (!System.IO.File.Exists(fullPath)) return Results.NotFound();
+    if (ValidatePdfRequest(name, out var fullPath) is { } error)
+    {
+        return error;
+    }
+
+    return Results.File(fullPath, "application/pdf", enableRangeProcessing: true);
+});
+
+// 3) ดาวน์โหลด (บังคับแนบไฟล์)
+app.MapGet("/api/pdfs/{name}/download", (string name) =>
+{
+    if (ValidatePdfRequest(name, out var fullPath) is { } error)
+    {
+        return error;
+    }
 
     var stream = System.IO.File.OpenRead(fullPath);
     return Results.File(stream, "application/pdf", fileDownloadName: name, enableRangeProcessing: true);


### PR DESCRIPTION
## Summary
- ensure inline PDF previews return without a download disposition so the iframe and new tab render directly
- add a shared validator helper and dedicated `/api/pdfs/{name}/download` endpoint for forced downloads
- update the UI download button to target the new download endpoint while previews keep the inline route

## Testing
- not run (dotnet CLI unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68df559231cc832f8887a085f5fe4fc0