### PR TITLE
Use field reference for iframe key

### DIFF
--- a/Components/Pages/PdfBrowser.razor
+++ b/Components/Pages/PdfBrowser.razor
@@ -49,7 +49,7 @@
                    href="@PreviewUrl(selected)" target="_blank">เปิดในแท็บใหม่</a>
             </div>
 
-            <iframe @key="previewNonce" style="width:100%; height:75vh; border:1px solid #ccc; border-radius:8px;"
+            <iframe @key=previewNonce style="width:100%; height:75vh; border:1px solid #ccc; border-radius:8px;"
                     src="@previewSrc"></iframe>
         }
         else


### PR DESCRIPTION
## Summary
- reference the previewNonce field when setting the iframe key so it updates correctly

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df9a648c68832fa14e67b4923c620b