### PR TITLE
Build LAN PDF browser with multi-folder support

### DIFF
--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -1,7 +1,0 @@
-﻿@page "/"
-
-<PageTitle>Home</PageTitle>
-
-<h1>Hello, world!</h1>
-
-Welcome to your new app.

--- a/Components/Pages/Index.razor
+++ b/Components/Pages/Index.razor
@@ -1,0 +1,198 @@
+@page "/"
+@using System.Net.Http.Json
+@inject HttpClient Http
+
+<PageTitle>PDF Browser</PageTitle>
+
+<h1 class="mb-4">📁 PDF Browser</h1>
+
+@if (!string.IsNullOrEmpty(linesError))
+{
+    <div class="alert alert-danger" role="alert">@linesError</div>
+}
+else if (isLoadingLines)
+{
+    <div class="text-muted">กำลังโหลดรายการโฟลเดอร์...</div>
+}
+else
+{
+    <div class="mb-4 d-flex flex-wrap gap-2">
+        @foreach (var line in AllLines)
+        {
+            var isAvailable = availableLines.Contains(line);
+            <button class="btn @(string.Equals(line, selectedLine, StringComparison.OrdinalIgnoreCase) ? "btn-primary" : "btn-outline-primary")"
+                    disabled="@(!isAvailable || (isLoadingFiles && !string.Equals(line, selectedLine, StringComparison.OrdinalIgnoreCase)))"
+                    @onclick="async () => await SelectLine(line)">
+                @line
+                @if (!isAvailable)
+                {
+                    <span class="ms-2 badge bg-secondary">ไม่พบ</span>
+                }
+            </button>
+        }
+    </div>
+
+    if (!availableLines.Any())
+    {
+        <div class="alert alert-warning" role="alert">
+            ไม่พบโฟลเดอร์ F1, F2 หรือ F3 บนเซิร์ฟเวอร์
+        </div>
+    }
+}
+
+@if (!string.IsNullOrEmpty(filesError))
+{
+    <div class="alert alert-danger" role="alert">@filesError</div>
+}
+else if (isLoadingFiles)
+{
+    <div class="text-muted">กำลังโหลดไฟล์ PDF...</div>
+}
+else if (selectedLine is not null)
+{
+    if (currentFiles is null)
+    {
+        <div class="text-muted">เลือกโฟลเดอร์เพื่อดูไฟล์ PDF</div>
+    }
+    else if (currentFiles.Count == 0)
+    {
+        <div class="alert alert-info" role="alert">โฟลเดอร์นี้ไม่มีไฟล์ PDF</div>
+    }
+    else
+    {
+        <div class="list-group mb-4">
+            @foreach (var file in currentFiles)
+            {
+                <div class="list-group-item d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <div class="text-break">@file</div>
+                    <div class="d-flex gap-2">
+                        <a class="btn btn-sm btn-outline-secondary"
+                           href="@BuildPdfUrl(selectedLine!, file)"
+                           target="_blank" rel="noopener noreferrer">เปิด</a>
+                        <button class="btn btn-sm btn-primary" @onclick="() => PreviewFile(file)">พรีวิว</button>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+}
+
+@if (!string.IsNullOrEmpty(previewFile) && selectedLine is not null)
+{
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <div>
+                <strong>Preview:</strong> @previewFile
+            </div>
+            <a class="btn btn-sm btn-outline-secondary"
+               href="@BuildPdfUrl(selectedLine!, previewFile!)"
+               target="_blank" rel="noopener noreferrer">เปิดในแท็บใหม่</a>
+        </div>
+        <div class="card-body p-0">
+            <iframe src="@BuildPdfUrl(selectedLine!, previewFile!)"
+                    style="width:100%; height:70vh; border:0;"
+                    title="PDF Preview"></iframe>
+        </div>
+    </div>
+}
+
+@code {
+    private static readonly string[] AllLines = ["F1", "F2", "F3"];
+
+    private readonly HashSet<string> availableLines = new(StringComparer.OrdinalIgnoreCase);
+    private List<string>? currentFiles;
+    private string? selectedLine;
+    private string? previewFile;
+    private bool isLoadingLines;
+    private bool isLoadingFiles;
+    private string? linesError;
+    private string? filesError;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadFoldersAsync();
+    }
+
+    private async Task LoadFoldersAsync()
+    {
+        try
+        {
+            isLoadingLines = true;
+            linesError = null;
+            var folders = await Http.GetFromJsonAsync<List<string>>("/api/folders");
+            availableLines.Clear();
+            if (folders is not null)
+            {
+                foreach (var folder in folders)
+                {
+                    availableLines.Add(folder);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            linesError = $"ไม่สามารถโหลดโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isLoadingLines = false;
+        }
+
+        if (availableLines.Count > 0 && selectedLine is null)
+        {
+            var preferred = AllLines.FirstOrDefault(line => availableLines.Contains(line));
+            if (preferred is not null)
+            {
+                await SelectLine(preferred);
+            }
+        }
+    }
+
+    private async Task SelectLine(string line)
+    {
+        if (!availableLines.Contains(line))
+        {
+            return;
+        }
+
+        if (string.Equals(selectedLine, line, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        selectedLine = line;
+        previewFile = null;
+        currentFiles = null;
+        await LoadFilesAsync(line);
+    }
+
+    private async Task LoadFilesAsync(string line)
+    {
+        try
+        {
+            isLoadingFiles = true;
+            filesError = null;
+            currentFiles = await Http.GetFromJsonAsync<List<string>>($"/api/folders/{Uri.EscapeDataString(line)}");
+            currentFiles ??= new List<string>();
+        }
+        catch (Exception ex)
+        {
+            filesError = $"ไม่สามารถโหลดไฟล์ได้: {ex.Message}";
+            currentFiles = new List<string>();
+        }
+        finally
+        {
+            isLoadingFiles = false;
+        }
+    }
+
+    private void PreviewFile(string file)
+    {
+        previewFile = file;
+    }
+
+    private static string BuildPdfUrl(string line, string file)
+    {
+        return $"/pdf/{Uri.EscapeDataString(line)}/{Uri.EscapeDataString(file)}";
+    }
+}

--- a/Components/Pages/PdfBrowser.razor
+++ b/Components/Pages/PdfBrowser.razor
@@ -23,9 +23,12 @@
                 @foreach (var f in Filtered)
                 {
                     <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <button class="btn btn-link p-0" @onclick="() => Select(f.name)">@f.name</button>
-                        <a class="btn btn-sm btn-outline-secondary"
-                           href="@($"/api/pdfs/{Uri.EscapeDataString(f.name)}/download")" target="_blank">ดาวน์โหลด</a>
+                        <span class="flex-grow-1 text-truncate me-3" title="@f.name">@f.name</span>
+                        <div class="btn-group" role="group">
+                            <button class="btn btn-sm btn-outline-primary" @onclick="() => Select(f.name)">แสดง</button>
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="@($"/api/pdfs/{Uri.EscapeDataString(f.name)}/download")" target="_blank">ดาวน์โหลด</a>
+                        </div>
                     </li>
                 }
             }
@@ -67,10 +70,13 @@
     {
         var endpoint = Navigation.ToAbsoluteUri("/api/pdfs");
         files = await Http.GetFromJsonAsync<List<PdfInfo>>(endpoint);
-        selected = files?.FirstOrDefault()?.name;
-    }
 
-    void Select(string name) => selected = name;
+        var initial = files?.FirstOrDefault();
+        if (initial is not null)
+        {
+            ApplySelection(initial.name, force: true);
+        }
+    }
 
     void Select(string name) => ApplySelection(name);
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
+using System.Net.Mime;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// เปิดโหมด Blazor Server
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
@@ -18,84 +19,120 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseAntiforgery();
 
-// ====== PDF APIs ======
-var pdfRoot = app.Configuration["PdfStorage:Root"]
-              ?? Path.Combine(app.Environment.ContentRootPath, "PDFs");
-Directory.CreateDirectory(pdfRoot);
-
-// กัน path traversal + บังคับ .pdf
-bool IsSafeFileName(string name)
+// ====== PDF browser configuration ======
+// TODO: Replace the UNC path below with the actual PDF root (e.g. @"D:\\PdfRoot")
+//       Ensure the web process identity has READ access on both the share and NTFS ACLs.
+var pdfRoot = builder.Configuration["PdfStorage:Root"]
+              ?? @"\\\\192.168.1.50\\PdfRoot";
+var allowedLines = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 {
-    if (!name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+    "F1",
+    "F2",
+    "F3"
+};
+
+static bool IsValidPdfFileName(string fileName)
+{
+    if (string.IsNullOrWhiteSpace(fileName))
     {
         return false;
     }
 
-    if (!string.Equals(Path.GetFileName(name), name, StringComparison.Ordinal))
+    if (!fileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
     {
         return false;
     }
 
-    return name.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+    if (!string.Equals(Path.GetFileName(fileName), fileName, StringComparison.Ordinal))
+    {
+        return false;
+    }
+
+    return fileName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
 }
 
-// 1) รายการไฟล์
-app.MapGet("/api/pdfs", () =>
+bool TryResolveLine(string line, out string? linePath)
 {
-    var files = Directory.EnumerateFiles(pdfRoot, "*.pdf", SearchOption.TopDirectoryOnly)
-                         .Select(full => new
-                         {
-                             name = Path.GetFileName(full),
-                             sizeBytes = new FileInfo(full).Length,
-                             modifiedUtc = File.GetLastWriteTimeUtc(full),
-                         })
-                         .OrderByDescending(f => f.modifiedUtc);
-    return Results.Ok(files);
-});
-
-IResult? ValidatePdfRequest(string name, out string fullPath)
-{
-    fullPath = string.Empty;
-    if (!IsSafeFileName(name))
+    linePath = null;
+    if (!allowedLines.Contains(line))
     {
-        return Results.BadRequest("invalid file name");
+        return false;
     }
 
-    var candidate = Path.Combine(pdfRoot, name);
+    var candidate = Path.Combine(pdfRoot, line);
+    if (!Directory.Exists(candidate))
+    {
+        return false;
+    }
+
+    linePath = candidate;
+    return true;
+}
+
+IResult? TryResolvePdf(string line, string file, out string? filePath)
+{
+    filePath = null;
+    if (!TryResolveLine(line, out var linePath))
+    {
+        return Results.NotFound("Unknown folder");
+    }
+
+    if (!IsValidPdfFileName(file))
+    {
+        return Results.BadRequest("Invalid PDF file name");
+    }
+
+    var candidate = Path.Combine(linePath!, file);
     if (!System.IO.File.Exists(candidate))
     {
         return Results.NotFound();
     }
 
-    fullPath = candidate;
+    filePath = candidate;
     return null;
 }
 
-// 2) พรีวิว inline
-app.MapGet("/api/pdfs/{name}", (string name) =>
+app.MapGet("/api/folders", () =>
 {
-    if (ValidatePdfRequest(name, out var fullPath) is { } error)
+    var existing = allowedLines
+        .Select(line => new { line, path = Path.Combine(pdfRoot, line) })
+        .Where(x => Directory.Exists(x.path))
+        .Select(x => x.line)
+        .OrderBy(line => line)
+        .ToList();
+
+    return Results.Ok(existing);
+});
+
+app.MapGet("/api/folders/{line}", (string line) =>
+{
+    if (!TryResolveLine(line, out var linePath))
+    {
+        return Results.NotFound();
+    }
+
+    var files = Directory.EnumerateFiles(linePath!, "*.pdf", SearchOption.TopDirectoryOnly)
+        .Where(path => IsValidPdfFileName(Path.GetFileName(path)))
+        .Select(Path.GetFileName)
+        .Where(name => name is not null)
+        .OrderBy(name => name)
+        .ToList()!;
+
+    return Results.Ok(files);
+});
+
+app.MapGet("/pdf/{line}/{file}", (string line, string file) =>
+{
+    if (TryResolvePdf(line, file, out var filePath) is { } error)
     {
         return error;
     }
 
-    return Results.File(fullPath, "application/pdf", enableRangeProcessing: true);
+    var stream = System.IO.File.OpenRead(filePath!);
+    return Results.File(stream, MediaTypeNames.Application.Pdf, enableRangeProcessing: true);
 });
+// ====== /PDF browser configuration ======
 
-// 3) ดาวน์โหลด (บังคับแนบไฟล์)
-app.MapGet("/api/pdfs/{name}/download", (string name) =>
-{
-    if (ValidatePdfRequest(name, out var fullPath) is { } error)
-    {
-        return error;
-    }
-
-    var stream = System.IO.File.OpenRead(fullPath);
-    return Results.File(stream, "application/pdf", fileDownloadName: name, enableRangeProcessing: true);
-});
-// ====== /PDF APIs ======
-
-// NOTE: เปลี่ยน BlazorPdfApp เป็นชื่อ namespace โปรเจกต์คุณถ้าไม่ตรง
 app.MapRazorComponents<BlazorPdfApp.Components.App>()
    .AddInteractiveServerRenderMode();
 


### PR DESCRIPTION
## Summary
- add minimal APIs for listing whitelisted folders, PDFs per folder, and streaming files with validation
- configure the PDF root path and document permission requirements in Program.cs
- replace the home page with a multi-folder PDF browser UI that supports inline previews and open-in-new-tab links

## Testing
- not run (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e35fcdd080832f91e767418ec9afdc