### PR TITLE
Add PDF upload support

### DIFF
--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -1,7 +1,0 @@
-﻿@page "/"
-
-<PageTitle>Home</PageTitle>
-
-<h1>Hello, world!</h1>
-
-Welcome to your new app.

--- a/Components/Pages/Index.razor
+++ b/Components/Pages/Index.razor
@@ -1,0 +1,346 @@
+@page "/"
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Text.Json
+@inject HttpClient Http
+@inject NavigationManager NavManager
+
+<PageTitle>PDF Browser</PageTitle>
+
+<h1 class="mb-4">📁 PDF Browser</h1>
+
+@if (!string.IsNullOrEmpty(linesError))
+{
+    <div class="alert alert-danger" role="alert">@linesError</div>
+}
+else if (isLoadingLines)
+{
+    <div class="text-muted">กำลังโหลดรายการโฟลเดอร์...</div>
+}
+else
+{
+    <div class="mb-4 d-flex flex-wrap gap-2">
+        @foreach (var line in AllLines)
+        {
+            var isAvailable = availableLines.Contains(line);
+            <button class="btn @(string.Equals(line, selectedLine, StringComparison.OrdinalIgnoreCase) ? "btn-primary" : "btn-outline-primary")"
+                    disabled="@(!isAvailable || (isLoadingFiles && !string.Equals(line, selectedLine, StringComparison.OrdinalIgnoreCase)))"
+                    @onclick="async () => await SelectLine(line)">
+                @line
+                @if (!isAvailable)
+                {
+                    <span class="ms-2 badge bg-secondary">ไม่พบ</span>
+                }
+            </button>
+        }
+    </div>
+
+    if (!availableLines.Any())
+    {
+        <div class="alert alert-warning" role="alert">
+            ไม่พบโฟลเดอร์ F1, F2 หรือ F3 บนเซิร์ฟเวอร์
+        </div>
+    }
+}
+
+@if (!string.IsNullOrEmpty(filesError))
+{
+    <div class="alert alert-danger" role="alert">@filesError</div>
+}
+else if (isLoadingFiles)
+{
+    <div class="text-muted">กำลังโหลดไฟล์ PDF...</div>
+}
+else if (selectedLine is not null)
+{
+    if (currentFiles is null)
+    {
+        <div class="text-muted">เลือกโฟลเดอร์เพื่อดูไฟล์ PDF</div>
+    }
+    else
+    {
+        <div class="card mb-4">
+            <div class="card-header">เพิ่มไฟล์ PDF ลงใน @selectedLine</div>
+            <div class="card-body d-flex flex-column flex-md-row gap-2 align-items-start align-items-md-center">
+                <InputFile OnChange="HandleFileSelected" accept=".pdf" disabled="@isUploadingFile" />
+                <div class="flex-grow-1">
+                    @if (!string.IsNullOrEmpty(pendingFileName))
+                    {
+                        <div class="text-muted small">ไฟล์ที่เลือก: @pendingFileName</div>
+                    }
+                    else
+                    {
+                        <div class="text-muted small">เลือกไฟล์ PDF เพื่ออัปโหลด</div>
+                    }
+                </div>
+                <button class="btn btn-success"
+                        disabled="@(!CanUpload)"
+                        @onclick="UploadSelectedFile">เพิ่มไฟล์</button>
+            </div>
+            @if (!string.IsNullOrEmpty(uploadError))
+            {
+                <div class="card-footer text-danger">@uploadError</div>
+            }
+            else if (!string.IsNullOrEmpty(uploadSuccess))
+            {
+                <div class="card-footer text-success">@uploadSuccess</div>
+            }
+        </div>
+
+        if (currentFiles.Count == 0)
+        {
+            <div class="alert alert-info" role="alert">โฟลเดอร์นี้ไม่มีไฟล์ PDF</div>
+        }
+        else
+        {
+            <div class="list-group mb-4">
+                @foreach (var file in currentFiles)
+                {
+                    <div class="list-group-item d-flex justify-content-between align-items-center flex-wrap gap-2">
+                        <div class="text-break">@file</div>
+                        <div class="d-flex gap-2">
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="@BuildPdfUrl(selectedLine!, file)"
+                               target="_blank" rel="noopener noreferrer">เปิด</a>
+                            <button class="btn btn-sm btn-primary" @onclick="() => PreviewFile(file)">พรีวิว</button>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    }
+}
+
+@if (!string.IsNullOrEmpty(previewFile) && selectedLine is not null)
+{
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <div>
+                <strong>Preview:</strong> @previewFile
+            </div>
+            <a class="btn btn-sm btn-outline-secondary"
+               href="@BuildPdfUrl(selectedLine!, previewFile!)"
+               target="_blank" rel="noopener noreferrer">เปิดในแท็บใหม่</a>
+        </div>
+        <div class="card-body p-0">
+            <iframe src="@BuildPdfUrl(selectedLine!, previewFile!)"
+                    style="width:100%; height:70vh; border:0;"
+                    title="PDF Preview"></iframe>
+        </div>
+    </div>
+}
+
+@code {
+    private static readonly string[] AllLines = ["F1", "F2", "F3"];
+    private const long MaxUploadBytes = 50L * 1024 * 1024;
+
+    private readonly HashSet<string> availableLines = new(StringComparer.OrdinalIgnoreCase);
+    private List<string>? currentFiles;
+    private string? selectedLine;
+    private string? previewFile;
+    private bool isLoadingLines;
+    private bool isLoadingFiles;
+    private bool isUploadingFile;
+    private string? linesError;
+    private string? filesError;
+    private string? uploadError;
+    private string? uploadSuccess;
+    private IBrowserFile? pendingUpload;
+    private string? pendingFileName;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadFoldersAsync();
+    }
+
+    private async Task LoadFoldersAsync()
+    {
+        try
+        {
+            isLoadingLines = true;
+            linesError = null;
+            var foldersEndpoint = NavManager.ToAbsoluteUri("/api/folders");
+            var folders = await Http.GetFromJsonAsync<List<string>>(foldersEndpoint);
+            availableLines.Clear();
+            if (folders is not null)
+            {
+                foreach (var folder in folders)
+                {
+                    availableLines.Add(folder);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            linesError = $"ไม่สามารถโหลดโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isLoadingLines = false;
+        }
+
+        if (availableLines.Count > 0 && selectedLine is null)
+        {
+            var preferred = AllLines.FirstOrDefault(line => availableLines.Contains(line));
+            if (preferred is not null)
+            {
+                await SelectLine(preferred);
+            }
+        }
+    }
+
+    private async Task SelectLine(string line)
+    {
+        if (!availableLines.Contains(line))
+        {
+            return;
+        }
+
+        if (string.Equals(selectedLine, line, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        selectedLine = line;
+        previewFile = null;
+        currentFiles = null;
+        ResetUploadState();
+        await LoadFilesAsync(line);
+    }
+
+    private async Task LoadFilesAsync(string line)
+    {
+        try
+        {
+            isLoadingFiles = true;
+            filesError = null;
+            var filesEndpoint = NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(line)}");
+            currentFiles = await Http.GetFromJsonAsync<List<string>>(filesEndpoint);
+            currentFiles ??= new List<string>();
+        }
+        catch (Exception ex)
+        {
+            filesError = $"ไม่สามารถโหลดไฟล์ได้: {ex.Message}";
+            currentFiles = new List<string>();
+        }
+        finally
+        {
+            isLoadingFiles = false;
+        }
+    }
+
+    private void PreviewFile(string file)
+    {
+        previewFile = file;
+    }
+
+    private static string BuildPdfUrl(string line, string file)
+    {
+        return $"/pdf/{Uri.EscapeDataString(line)}/{Uri.EscapeDataString(file)}";
+    }
+
+    private void HandleFileSelected(InputFileChangeEventArgs e)
+    {
+        uploadError = null;
+        uploadSuccess = null;
+        pendingUpload = null;
+        pendingFileName = null;
+
+        var file = e.File;
+        if (file is null)
+        {
+            uploadError = "ไม่พบไฟล์ที่เลือก";
+            return;
+        }
+
+        if (!file.Name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+        {
+            uploadError = "กรุณาเลือกไฟล์ PDF (.pdf)";
+            return;
+        }
+
+        pendingUpload = file;
+        pendingFileName = file.Name;
+    }
+
+    private bool CanUpload => selectedLine is not null && pendingUpload is not null && !isUploadingFile;
+
+    private async Task UploadSelectedFile()
+    {
+        if (!CanUpload || selectedLine is null || pendingUpload is null)
+        {
+            return;
+        }
+
+        uploadError = null;
+        uploadSuccess = null;
+        isUploadingFile = true;
+
+        try
+        {
+            var uploadEndpoint = NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(selectedLine)}/upload");
+            using var content = new MultipartFormDataContent();
+            var stream = pendingUpload.OpenReadStream(MaxUploadBytes);
+            var streamContent = new StreamContent(stream);
+            streamContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
+            content.Add(streamContent, "file", pendingUpload.Name);
+
+            var response = await Http.PostAsync(uploadEndpoint, content);
+            if (response.IsSuccessStatusCode)
+            {
+                var uploadedName = pendingFileName ?? pendingUpload.Name;
+                uploadSuccess = string.IsNullOrEmpty(uploadedName)
+                    ? "อัปโหลดไฟล์เรียบร้อย"
+                    : $"อัปโหลดไฟล์ {uploadedName} เรียบร้อย";
+                await LoadFilesAsync(selectedLine);
+                pendingUpload = null;
+                pendingFileName = null;
+            }
+            else
+            {
+                var message = await response.Content.ReadAsStringAsync();
+                var mediaType = response.Content.Headers.ContentType?.MediaType;
+                if (string.Equals(mediaType, "application/problem+json", StringComparison.OrdinalIgnoreCase))
+                {
+                    try
+                    {
+                        using var doc = JsonDocument.Parse(message);
+                        if (doc.RootElement.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
+                        {
+                            message = detail.GetString() ?? message;
+                        }
+                        else if (doc.RootElement.TryGetProperty("title", out var title) && title.ValueKind == JsonValueKind.String)
+                        {
+                            message = title.GetString() ?? message;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // ignore parsing failures and fall back to raw message
+                    }
+                }
+
+                uploadError = string.IsNullOrWhiteSpace(message)
+                    ? $"อัปโหลดไม่สำเร็จ (รหัส {response.StatusCode})"
+                    : message;
+            }
+        }
+        catch (Exception ex)
+        {
+            uploadError = $"อัปโหลดไม่สำเร็จ: {ex.Message}";
+        }
+        finally
+        {
+            isUploadingFile = false;
+        }
+    }
+
+    private void ResetUploadState()
+    {
+        isUploadingFile = false;
+        uploadError = null;
+        uploadSuccess = null;
+        pendingUpload = null;
+        pendingFileName = null;
+    }
+}

--- a/Components/Pages/PdfBrowser.razor
+++ b/Components/Pages/PdfBrowser.razor
@@ -1,16 +1,38 @@
 @page "/pdfs"
 @using System
+@using System.Collections.Generic
+@using System.Linq
 @using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
 @inject HttpClient Http
-@inject NavigationManager Navigation
+@inject NavigationManager NavManager
 
 <h2 class="mb-3">📄 PDF Browser (Local Server)</h2>
 
+<div class="mb-3">
+    <label class="form-label fw-semibold">เลือกโฟลเดอร์</label>
+    <select class="form-select" value="@selectedLine" @onchange="HandleFolderChanged" disabled="@isLoadingFolders">
+        <option value="" disabled>-- เลือกโฟลเดอร์ --</option>
+        @foreach (var line in availableLines)
+        {
+            <option value="@line">@line</option>
+        }
+    </select>
+    @if (!string.IsNullOrEmpty(foldersError))
+    {
+        <div class="alert alert-danger mt-2" role="alert">@foldersError</div>
+    }
+</div>
+
 <div class="row">
-    <div class="col-4">
-        <input class="form-control mb-2" placeholder="ค้นหาไฟล์..." @bind="search" @bind:event="oninput" />
+    <div class="col-12 col-lg-4 mb-3 mb-lg-0">
+        <input class="form-control mb-2"
+               placeholder="ค้นหาไฟล์..."
+               @bind="search"
+               @bind:event="oninput"
+               disabled="@isLoadingFiles" />
         <ul class="list-group" style="max-height: 70vh; overflow:auto;">
-            @if (files is null)
+            @if (isLoadingFiles)
             {
                 <li class="list-group-item">กำลังโหลด...</li>
             }
@@ -22,29 +44,40 @@
             {
                 @foreach (var f in Filtered)
                 {
-                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <button class="btn btn-link p-0" @onclick="() => Select(f.name)">@f.name</button>
-                        <a class="btn btn-sm btn-outline-secondary"
-                           href="@($"/api/pdfs/{Uri.EscapeDataString(f.name)}/download")" target="_blank">ดาวน์โหลด</a>
+                    <li class="list-group-item d-flex justify-content-between align-items-center @(string.Equals(selected, f, StringComparison.Ordinal) ? "active" : string.Empty)">
+                        <span class="flex-grow-1 text-truncate me-3" title="@f">@f</span>
+                        <div class="btn-group" role="group">
+                            <button class="btn btn-sm btn-outline-primary" @onclick="() => Select(f)" disabled="@string.IsNullOrEmpty(selectedLine)">แสดง</button>
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="@(selectedLine is null ? null : BuildPdfUrl(selectedLine, f))"
+                               target="_blank" rel="noopener noreferrer"
+                               aria-disabled="@(selectedLine is null)">เปิด</a>
+                        </div>
                     </li>
                 }
             }
         </ul>
     </div>
 
-    <div class="col-8">
-        @if (!string.IsNullOrEmpty(selected))
+    <div class="col-12 col-lg-8">
+        @if (!string.IsNullOrEmpty(filesError))
+        {
+            <div class="alert alert-danger" role="alert">@filesError</div>
+        }
+        else if (!string.IsNullOrEmpty(selected) && !string.IsNullOrEmpty(selectedLine))
         {
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h5 class="m-0">พรีวิว: @selected</h5>
                 <a class="btn btn-sm btn-primary"
-                   href="@($"/api/pdfs/{Uri.EscapeDataString(selected)}")" target="_blank">เปิดในแท็บใหม่</a>
+                   href="@BuildPdfUrl(selectedLine!, selected)"
+                   target="_blank" rel="noopener noreferrer">เปิดในแท็บใหม่</a>
             </div>
 
             <iframe style="width:100%; height:75vh; border:1px solid #ccc; border-radius:8px;"
-                    src="@($"/api/pdfs/{Uri.EscapeDataString(selected)}")"></iframe>
+                    src="@BuildPdfUrl(selectedLine!, selected)"
+                    title="PDF Preview"></iframe>
         }
-        else
+        else if (!isLoadingFiles)
         {
             <div class="text-muted">เลือกไฟล์ทางซ้ายเพื่อดูพรีวิว</div>
         }
@@ -52,48 +85,121 @@
 </div>
 
 @code {
-    record PdfInfo(string name, long sizeBytes, DateTime modifiedUtc);
-    List<PdfInfo>? files;
+    readonly List<string> availableLines = new();
+    List<string>? files;
+    string? selectedLine;
     string? selected;
+    string? foldersError;
+    string? filesError;
+    bool isLoadingFolders;
+    bool isLoadingFiles;
 
-    string? previewSrc;
-    Guid previewNonce = Guid.Empty;
-    string search = "";
+    string search = string.Empty;
 
-    IEnumerable<PdfInfo> Filtered => (files ?? Enumerable.Empty<PdfInfo>())
-        .Where(f => string.IsNullOrWhiteSpace(search) || f.name.Contains(search, StringComparison.OrdinalIgnoreCase));
+    IEnumerable<string> Filtered => (files ?? Enumerable.Empty<string>())
+        .Where(f => string.IsNullOrWhiteSpace(search) || f.Contains(search, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = Navigation.ToAbsoluteUri("/api/pdfs");
-        files = await Http.GetFromJsonAsync<List<PdfInfo>>(endpoint);
-        selected = files?.FirstOrDefault()?.name;
+        await LoadFoldersAsync();
     }
 
-    void Select(string name) => selected = name;
+    async Task LoadFoldersAsync()
+    {
+        try
+        {
+            isLoadingFolders = true;
+            foldersError = null;
+            var folders = await Http.GetFromJsonAsync<List<string>>(NavManager.ToAbsoluteUri("/api/folders"));
+            availableLines.Clear();
+            if (folders is not null)
+            {
+                foreach (var folder in folders)
+                {
+                    availableLines.Add(folder);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            foldersError = $"ไม่สามารถโหลดโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isLoadingFolders = false;
+        }
+
+        if (availableLines.Count > 0)
+        {
+            var nextLine = GetMatchingLine(selectedLine) ?? availableLines.First();
+            await LoadFilesAsync(nextLine);
+        }
+        else
+        {
+            selectedLine = null;
+            files = new List<string>();
+            selected = null;
+        }
+    }
+
+    async Task LoadFilesAsync(string line)
+    {
+        selectedLine = line;
+        selected = null;
+        filesError = null;
+        try
+        {
+            isLoadingFiles = true;
+            files = await Http.GetFromJsonAsync<List<string>>(NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(line)}"));
+            files ??= new List<string>();
+        }
+        catch (Exception ex)
+        {
+            filesError = $"ไม่สามารถโหลดไฟล์ได้: {ex.Message}";
+            files = new List<string>();
+        }
+        finally
+        {
+            isLoadingFiles = false;
+        }
+
+        var first = files.FirstOrDefault();
+        if (first is not null)
+        {
+            ApplySelection(first, force: true);
+        }
+    }
 
     void Select(string name) => ApplySelection(name);
 
-    string PreviewUrl(string name) => $"/api/pdfs/{Uri.EscapeDataString(name)}";
-
-    string BuildPreviewSource(string name, Guid nonce)
+    async Task HandleFolderChanged(ChangeEventArgs args)
     {
-        var baseUri = Navigation.ToAbsoluteUri(PreviewUrl(name)).ToString();
-        var separator = baseUri.Contains('?') ? '&' : '?';
-        return $"{baseUri}{separator}v={nonce}";
-    }
-
-    string DownloadUrl(string name) => $"{PreviewUrl(name)}/download";
-
-    string GetItemClasses(string name)
-    {
-        var classes = "list-group-item";
-        if (string.Equals(selected, name, StringComparison.Ordinal))
+        var line = args.Value?.ToString();
+        var match = GetMatchingLine(line);
+        if (!string.IsNullOrWhiteSpace(match))
         {
-            classes += " active";
+            await LoadFilesAsync(match);
+            return;
         }
 
-        return classes;
+        selectedLine = null;
+        files = new List<string>();
+        selected = null;
+    }
+
+    static string BuildPdfUrl(string line, string name)
+    {
+        return $"/pdf/{Uri.EscapeDataString(line)}/{Uri.EscapeDataString(name)}";
+    }
+
+    string? GetMatchingLine(string? line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return null;
+        }
+
+        return availableLines.FirstOrDefault(l => string.Equals(l, line, StringComparison.OrdinalIgnoreCase));
     }
 
     bool ApplySelection(string name, bool force = false)
@@ -104,8 +210,6 @@
         }
 
         selected = name;
-        previewNonce = Guid.NewGuid();
-        previewSrc = BuildPreviewSource(name, previewNonce);
         return true;
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,18 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Http.Features;
+
+const long MaxUploadBytes = 50L * 1024 * 1024; // 50 MB upload limit per PDF
+
 var builder = WebApplication.CreateBuilder(args);
 
-// เปิดโหมด Blazor Server
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddHttpClient();
+builder.Services.Configure<FormOptions>(options =>
+{
+    options.MultipartBodyLengthLimit = MaxUploadBytes;
+});
 
 var app = builder.Build();
 
@@ -18,84 +26,201 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseAntiforgery();
 
-// ====== PDF APIs ======
-var pdfRoot = app.Configuration["PdfStorage:Root"]
-              ?? Path.Combine(app.Environment.ContentRootPath, "PDFs");
-Directory.CreateDirectory(pdfRoot);
+// ====== PDF browser configuration ======
+// TODO: Replace the UNC path below with the actual PDF root if it differs in your environment.
+//       Ensure the web process identity has READ/WRITE access on both the share and NTFS ACLs.
+var pdfRoot = builder.Configuration["PdfStorage:Root"]
+              ?? @"\\\\10.192.132.91\\PdfRoot";
 
-// กัน path traversal + บังคับ .pdf
-bool IsSafeFileName(string name)
+if (!Directory.Exists(pdfRoot))
 {
-    if (!name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+    app.Logger.LogWarning("Configured PDF root '{PdfRoot}' is not accessible. Confirm the share path and permissions.", pdfRoot);
+}
+var allowedLines = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+{
+    "F1",
+    "F2",
+    "F3"
+};
+
+static bool IsValidPdfFileName(string fileName)
+{
+    if (string.IsNullOrWhiteSpace(fileName))
     {
         return false;
     }
 
-    if (!string.Equals(Path.GetFileName(name), name, StringComparison.Ordinal))
+    if (!fileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
     {
         return false;
     }
 
-    return name.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+    if (!string.Equals(Path.GetFileName(fileName), fileName, StringComparison.Ordinal))
+    {
+        return false;
+    }
+
+    return fileName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
 }
 
-// 1) รายการไฟล์
-app.MapGet("/api/pdfs", () =>
+bool TryResolveLine(string line, out string? linePath)
 {
-    var files = Directory.EnumerateFiles(pdfRoot, "*.pdf", SearchOption.TopDirectoryOnly)
-                         .Select(full => new
-                         {
-                             name = Path.GetFileName(full),
-                             sizeBytes = new FileInfo(full).Length,
-                             modifiedUtc = File.GetLastWriteTimeUtc(full),
-                         })
-                         .OrderByDescending(f => f.modifiedUtc);
-    return Results.Ok(files);
-});
-
-IResult? ValidatePdfRequest(string name, out string fullPath)
-{
-    fullPath = string.Empty;
-    if (!IsSafeFileName(name))
+    linePath = null;
+    if (!allowedLines.Contains(line))
     {
-        return Results.BadRequest("invalid file name");
+        return false;
     }
 
-    var candidate = Path.Combine(pdfRoot, name);
+    var candidate = Path.Combine(pdfRoot, line);
+    if (!Directory.Exists(candidate))
+    {
+        return false;
+    }
+
+    linePath = candidate;
+    return true;
+}
+
+IResult? TryResolvePdf(string line, string file, out string? filePath)
+{
+    filePath = null;
+    if (!TryResolveLine(line, out var linePath))
+    {
+        return Results.NotFound("Unknown folder");
+    }
+
+    if (!IsValidPdfFileName(file))
+    {
+        return Results.BadRequest("Invalid PDF file name");
+    }
+
+    var candidate = Path.Combine(linePath!, file);
     if (!System.IO.File.Exists(candidate))
     {
         return Results.NotFound();
     }
 
-    fullPath = candidate;
+    filePath = candidate;
     return null;
 }
 
-// 2) พรีวิว inline
-app.MapGet("/api/pdfs/{name}", (string name) =>
+app.MapGet("/api/folders", () =>
 {
-    if (ValidatePdfRequest(name, out var fullPath) is { } error)
+    try
+    {
+        var existing = allowedLines
+            .Select(line => new { line, path = Path.Combine(pdfRoot, line) })
+            .Where(x => Directory.Exists(x.path))
+            .Select(x => x.line)
+            .OrderBy(line => line)
+            .ToList();
+
+        return Results.Ok(existing);
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to enumerate folders under {PdfRoot}", pdfRoot);
+        return Results.Problem("ไม่สามารถอ่านรายการโฟลเดอร์ได้ กรุณาตรวจสอบการแชร์และสิทธิ์การเข้าถึง");
+    }
+});
+
+app.MapGet("/api/folders/{line}", (string line) =>
+{
+    if (!TryResolveLine(line, out var linePath))
+    {
+        return Results.NotFound();
+    }
+
+    try
+    {
+        var files = Directory.EnumerateFiles(linePath!, "*.pdf", SearchOption.TopDirectoryOnly)
+            .Where(path => IsValidPdfFileName(Path.GetFileName(path)))
+            .Select(Path.GetFileName)
+            .Where(name => name is not null)
+            .OrderBy(name => name)
+            .ToList()!;
+
+        return Results.Ok(files);
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to enumerate files for {Line} in {PdfRoot}", line, pdfRoot);
+        return Results.Problem("ไม่สามารถอ่านไฟล์ในโฟลเดอร์ที่เลือกได้ กรุณาตรวจสอบสิทธิ์การเข้าถึง");
+    }
+});
+
+app.MapGet("/pdf/{line}/{file}", (string line, string file) =>
+{
+    if (TryResolvePdf(line, file, out var filePath) is { } error)
     {
         return error;
     }
 
-    return Results.File(fullPath, "application/pdf", enableRangeProcessing: true);
+    try
+    {
+        var stream = System.IO.File.OpenRead(filePath!);
+        return Results.File(stream, MediaTypeNames.Application.Pdf, enableRangeProcessing: true);
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to open PDF {File} for line {Line}", file, line);
+        return Results.Problem("ไม่สามารถเปิดไฟล์ PDF ได้ กรุณาตรวจสอบการแชร์และสิทธิ์การเข้าถึง");
+    }
 });
 
-// 3) ดาวน์โหลด (บังคับแนบไฟล์)
-app.MapGet("/api/pdfs/{name}/download", (string name) =>
+app.MapPost("/api/folders/{line}/upload", async (string line, HttpRequest request) =>
 {
-    if (ValidatePdfRequest(name, out var fullPath) is { } error)
+    if (!TryResolveLine(line, out var linePath))
     {
-        return error;
+        return Results.NotFound("Unknown folder");
     }
 
-    var stream = System.IO.File.OpenRead(fullPath);
-    return Results.File(stream, "application/pdf", fileDownloadName: name, enableRangeProcessing: true);
-});
-// ====== /PDF APIs ======
+    if (!request.HasFormContentType)
+    {
+        return Results.BadRequest("ต้องเป็น multipart/form-data");
+    }
 
-// NOTE: เปลี่ยน BlazorPdfApp เป็นชื่อ namespace โปรเจกต์คุณถ้าไม่ตรง
+    try
+    {
+        var form = await request.ReadFormAsync();
+        var formFile = form.Files.GetFile("file");
+
+        if (formFile is null || formFile.Length == 0)
+        {
+            return Results.BadRequest("ไม่พบไฟล์หรือไฟล์ว่าง");
+        }
+
+        var originalName = Path.GetFileName(formFile.FileName);
+        if (!IsValidPdfFileName(originalName))
+        {
+            return Results.BadRequest("รองรับเฉพาะไฟล์ .pdf เท่านั้น");
+        }
+
+        if (formFile.Length > MaxUploadBytes)
+        {
+            return Results.BadRequest($"ไฟล์มีขนาดเกิน {MaxUploadBytes / (1024 * 1024)} MB");
+        }
+
+        var destination = Path.Combine(linePath!, originalName);
+        if (System.IO.File.Exists(destination))
+        {
+            return Results.Conflict("ไฟล์นี้มีอยู่แล้ว");
+        }
+
+        await using var readStream = formFile.OpenReadStream(MaxUploadBytes);
+        await using var writeStream = new FileStream(destination, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        await readStream.CopyToAsync(writeStream);
+
+        return Results.Ok(new { file = originalName });
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to upload PDF to {Line}", line);
+        return Results.Problem("ไม่สามารถอัปโหลดไฟล์ได้ กรุณาตรวจสอบสิทธิ์การเข้าถึง");
+    }
+});
+// ====== /PDF browser configuration ======
+
 app.MapRazorComponents<BlazorPdfApp.Components.App>()
    .AddInteractiveServerRenderMode();
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -2,6 +2,6 @@
   "Logging": { "LogLevel": { "Default": "Information", "Microsoft.AspNetCore": "Warning" } },
   "AllowedHosts": "*",
   "PdfStorage": {
-    "Root": "D:\\LocalShare\\PDFs"
+    "Root": "\\\\10.192.132.91\\PdfRoot"
   }
 }


### PR DESCRIPTION
## Summary
- add a multipart upload endpoint that enforces the PDF whitelist, size checks, and share permissions before saving
- configure the server to accept 50 MB uploads and document the need for write access on the share
- extend the home page to select a PDF file, upload it into the active folder, and surface success or problem+json errors with refreshed listings

## Testing
- not run (dotnet SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e35fcdd080832f91e767418ec9afdc