### PR TITLE
Add document edit status dashboard

### DIFF
--- a/Components/Pages/Edit.razor
+++ b/Components/Pages/Edit.razor
@@ -1,0 +1,232 @@
+@page "/edit"
+@using System.Net.Http.Json
+@inject HttpClient Http
+@inject NavigationManager NavManager
+
+<PageTitle>สถานะแก้ไขเอกสาร</PageTitle>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center align-items-start gap-2 mb-4">
+    <h1 class="mb-0">สถานะแก้ไขเอกสาร</h1>
+    <button class="btn btn-outline-secondary" @onclick="RefreshAsync" disabled="@isLoading">
+        @if (isLoading)
+        {
+            <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+        }
+        <span>รีเฟรช</span>
+    </button>
+</div>
+
+@if (!string.IsNullOrEmpty(errorMessage))
+{
+    <div class="alert alert-danger" role="alert">@errorMessage</div>
+}
+else if (isLoading)
+{
+    <div class="text-muted">กำลังโหลดสถานะการแก้ไข...</div>
+}
+else if (lineStatuses is null || lineStatuses.Count == 0)
+{
+    <div class="alert alert-info" role="alert">ยังไม่มีข้อมูลสถานะการแก้ไข</div>
+}
+else
+{
+    foreach (var line in lineStatuses)
+    {
+        <div class="card mb-4 shadow-sm">
+            <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+                <div class="fs-5 fw-semibold">@line.Line</div>
+                @if (!string.IsNullOrEmpty(line.ErrorMessage))
+                {
+                    <span class="badge bg-danger">ไม่สามารถอ่านข้อมูล</span>
+                }
+                else if (line.Root is not null)
+                {
+                    <span class="badge bg-primary">@line.Root.Status</span>
+                }
+            </div>
+            <div class="card-body">
+                @if (!string.IsNullOrEmpty(line.ErrorMessage))
+                {
+                    <div class="alert alert-danger mb-0">@line.ErrorMessage</div>
+                }
+                else if (line.Root is null)
+                {
+                    <div class="text-muted">ไม่มีข้อมูลสถานะสำหรับโฟลเดอร์นี้</div>
+                }
+                else
+                {
+                    <div class="row g-3 mb-3">
+                        <div class="col-12 col-md-4">
+                            <div class="text-muted text-uppercase small">จำนวนไฟล์ทั้งหมด</div>
+                            <div class="fw-semibold">@line.Root.TotalPdfCount</div>
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <div class="text-muted text-uppercase small">อัปเดตล่าสุด</div>
+                            <div class="fw-semibold">
+                                @(line.Root.LastModifiedUtc is DateTime last
+                                    ? last.ToLocalTime().ToString("g")
+                                    : "-")
+                            </div>
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <div class="text-muted text-uppercase small">สถานะ</div>
+                            <div class="fw-semibold">@line.Root.Status</div>
+                        </div>
+                    </div>
+
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th scope="col">กิ่ง / โฟลเดอร์</th>
+                                    <th scope="col" class="text-center">ไฟล์ในกิ่ง</th>
+                                    <th scope="col" class="text-center">ไฟล์รวม</th>
+                                    <th scope="col">อัปเดตล่าสุด</th>
+                                    <th scope="col">สถานะ</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var entry in EnumerateBranchTree(line.Root))
+                                {
+                                    var branch = entry.Branch;
+                                    <tr>
+                                        <td style="@GetIndentStyle(entry.Depth)">
+                                            <div class="fw-semibold">@branch.Name</div>
+                                            @if (branch.PathSegments.Count > 0)
+                                            {
+                                                <div class="small text-muted">@string.Join("/", branch.PathSegments)</div>
+                                            }
+                                            @if (!string.IsNullOrEmpty(branch.ErrorMessage))
+                                            {
+                                                <div class="small text-danger">@branch.ErrorMessage</div>
+                                            }
+                                            else if (branch.RecentFiles.Count > 0)
+                                            {
+                                                <div class="small text-muted">
+                                                    ล่าสุด:
+                                                    @for (var i = 0; i < branch.RecentFiles.Count; i++)
+                                                    {
+                                                        var file = branch.RecentFiles[i];
+                                                        <span>@file.FileName (@file.LastModifiedUtc.ToLocalTime().ToString("g"))</span>
+                                                        @if (i < branch.RecentFiles.Count - 1)
+                                                        {
+                                                            <span>, </span>
+                                                        }
+                                                    }
+                                                </div>
+                                            }
+                                        </td>
+                                        <td class="text-center">@branch.PdfCount</td>
+                                        <td class="text-center">@branch.TotalPdfCount</td>
+                                        <td>
+                                            @(branch.LastModifiedUtc is DateTime branchLast
+                                                ? branchLast.ToLocalTime().ToString("g")
+                                                : "-")
+                                        </td>
+                                        <td>
+                                            @if (!string.IsNullOrEmpty(branch.ErrorMessage))
+                                            {
+                                                <span class="text-danger">@branch.ErrorMessage</span>
+                                            }
+                                            else
+                                            {
+                                                @branch.Status
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+}
+
+@code {
+    private List<LineEditStatusResponse>? lineStatuses;
+    private bool isLoading = true;
+    private string? errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStatusesAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        await LoadStatusesAsync();
+    }
+
+    private async Task LoadStatusesAsync()
+    {
+        try
+        {
+            isLoading = true;
+            errorMessage = null;
+
+            var endpoint = NavManager.ToAbsoluteUri("/api/edit-status");
+            var result = await Http.GetFromJsonAsync<List<LineEditStatusResponse>>(endpoint);
+            lineStatuses = result ?? new List<LineEditStatusResponse>();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"ไม่สามารถโหลดสถานะแก้ไขได้: {ex.Message}";
+            lineStatuses = null;
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private static string GetIndentStyle(int depth)
+        => depth <= 0 ? string.Empty : $"padding-left: {Math.Min(depth * 1.5, 6)}rem;";
+
+    private static IEnumerable<(BranchEditStatusResponse Branch, int Depth)> EnumerateBranchTree(BranchEditStatusResponse root)
+    {
+        var stack = new Stack<(BranchEditStatusResponse Branch, int Depth)>();
+        stack.Push((root, 0));
+
+        while (stack.Count > 0)
+        {
+            var (branch, depth) = stack.Pop();
+            yield return (branch, depth);
+
+            for (var i = branch.Children.Count - 1; i >= 0; i--)
+            {
+                stack.Push((branch.Children[i], depth + 1));
+            }
+        }
+    }
+
+    private sealed class LineEditStatusResponse
+    {
+        public string Line { get; set; } = string.Empty;
+        public BranchEditStatusResponse? Root { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+
+    private sealed class BranchEditStatusResponse
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<string> PathSegments { get; set; } = new();
+        public int PdfCount { get; set; }
+        public int TotalPdfCount { get; set; }
+        public DateTime? LastModifiedUtc { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public List<FileEditStatusResponse> RecentFiles { get; set; } = new();
+        public List<BranchEditStatusResponse> Children { get; set; } = new();
+        public string? ErrorMessage { get; set; }
+    }
+
+    private sealed class FileEditStatusResponse
+    {
+        public string FileName { get; set; } = string.Empty;
+        public DateTime LastModifiedUtc { get; set; }
+        public long SizeBytes { get; set; }
+        public string RelativePath { get; set; } = string.Empty;
+    }
+}

--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -1,7 +1,0 @@
-﻿@page "/"
-
-<PageTitle>Home</PageTitle>
-
-<h1>Hello, world!</h1>
-
-Welcome to your new app.

--- a/Components/Pages/Index.razor
+++ b/Components/Pages/Index.razor
@@ -1,0 +1,616 @@
+@page "/"
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Text.Json
+@using System.Linq
+@inject HttpClient Http
+@inject NavigationManager NavManager
+
+<PageTitle>PDF Browser</PageTitle>
+
+<h1 class="mb-4">📁 PDF Browser</h1>
+
+@if (!string.IsNullOrEmpty(linesError))
+{
+    <div class="alert alert-danger" role="alert">@linesError</div>
+}
+else if (isLoadingLines)
+{
+    <div class="text-muted">กำลังโหลดรายการโฟลเดอร์...</div>
+}
+else
+{
+    <div class="mb-4 d-flex flex-wrap gap-2">
+        @foreach (var line in AllLines)
+        {
+            var isAvailable = availableLines.Contains(line);
+            <button class="btn @(string.Equals(line, selectedLine, StringComparison.OrdinalIgnoreCase) ? "btn-primary" : "btn-outline-primary")"
+                    disabled="@(!isAvailable || (isLoadingFiles && !string.Equals(line, selectedLine, StringComparison.OrdinalIgnoreCase)))"
+                    @onclick="async () => await SelectLine(line)">
+                @line
+                @if (!isAvailable)
+                {
+                    <span class="ms-2 badge bg-secondary">ไม่พบ</span>
+                }
+            </button>
+        }
+    </div>
+
+    if (!availableLines.Any())
+    {
+        <div class="alert alert-warning" role="alert">
+            ไม่พบโฟลเดอร์ F1, F2 หรือ F3 บนเซิร์ฟเวอร์
+        </div>
+    }
+}
+
+@if (!string.IsNullOrEmpty(filesError))
+{
+    <div class="alert alert-danger" role="alert">@filesError</div>
+}
+else if (isLoadingFiles)
+{
+    <div class="text-muted">กำลังโหลดไฟล์ PDF...</div>
+}
+else if (selectedLine is not null)
+{
+    if (currentFiles is null)
+    {
+        <div class="text-muted">เลือกโฟลเดอร์เพื่อดูไฟล์ PDF</div>
+    }
+    else
+    {
+        <nav class="mb-3" aria-label="breadcrumb">
+            <ol class="breadcrumb mb-0">
+                <li class="breadcrumb-item @(currentPathSegments.Count == 0 ? "active" : null)"
+                    aria-current="@(currentPathSegments.Count == 0 ? "page" : null)">
+                    @if (currentPathSegments.Count == 0)
+                    {
+                        @selectedLine
+                    }
+                    else
+                    {
+                        <button class="btn btn-link p-0"
+                                type="button"
+                                @onclick="async () => await NavigateToRootAsync()">@selectedLine</button>
+                    }
+                </li>
+                @for (var i = 0; i < currentPathSegments.Count; i++)
+                {
+                    var folderName = currentPathSegments[i];
+                    var isLast = i == currentPathSegments.Count - 1;
+                    <li class="breadcrumb-item @(isLast ? "active" : null)"
+                        aria-current="@(isLast ? "page" : null)">
+                        @if (isLast)
+                        {
+                            @folderName
+                        }
+                        else
+                        {
+                            <button class="btn btn-link p-0"
+                                    type="button"
+                                    @onclick="async () => await NavigateToBreadcrumbAsync(i)">@folderName</button>
+                        }
+                    </li>
+                }
+            </ol>
+        </nav>
+
+        <div class="card mb-4">
+            <div class="card-header">สร้างโฟลเดอร์สำหรับโมเดลใน @GetCurrentPathDisplay()</div>
+            <div class="card-body d-flex flex-column flex-md-row gap-2 align-items-start align-items-md-center">
+                <input class="form-control"
+                       placeholder="ชื่อโฟลเดอร์ (เช่น Model A)"
+                       @bind="newFolderName"
+                       @bind:event="oninput"
+                       disabled="@isCreatingFolder" />
+                <button class="btn btn-outline-primary"
+                        disabled="@(!CanCreateFolder)"
+                        @onclick="CreateFolderAsync">เพิ่มโฟลเดอร์</button>
+            </div>
+            @if (!string.IsNullOrEmpty(createFolderError))
+            {
+                <div class="card-footer text-danger">@createFolderError</div>
+            }
+            else if (!string.IsNullOrEmpty(createFolderSuccess))
+            {
+                <div class="card-footer text-success">@createFolderSuccess</div>
+            }
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">เพิ่มไฟล์ PDF ลงใน @GetCurrentPathDisplay()</div>
+            <div class="card-body d-flex flex-column flex-md-row gap-2 align-items-start align-items-md-center">
+                <InputFile OnChange="HandleFileSelected" accept=".pdf" disabled="@isUploadingFile" />
+                <div class="flex-grow-1">
+                    @if (!string.IsNullOrEmpty(pendingFileName))
+                    {
+                        <div class="text-muted small">ไฟล์ที่เลือก: @pendingFileName</div>
+                    }
+                    else
+                    {
+                        <div class="text-muted small">เลือกไฟล์ PDF เพื่ออัปโหลด</div>
+                    }
+                </div>
+                <button class="btn btn-success"
+                        disabled="@(!CanUpload)"
+                        @onclick="UploadSelectedFile">เพิ่มไฟล์</button>
+            </div>
+            @if (!string.IsNullOrEmpty(uploadError))
+            {
+                <div class="card-footer text-danger">@uploadError</div>
+            }
+            else if (!string.IsNullOrEmpty(uploadSuccess))
+            {
+                <div class="card-footer text-success">@uploadSuccess</div>
+            }
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">โฟลเดอร์ภายใน @GetCurrentPathDisplay()</div>
+            <div class="list-group list-group-flush">
+                @if (currentFolders.Count == 0)
+                {
+                    <div class="list-group-item text-muted">ไม่มีโฟลเดอร์ย่อย</div>
+                }
+                else
+                {
+                    @foreach (var folder in currentFolders)
+                    {
+                        <div class="list-group-item d-flex justify-content-between align-items-center flex-wrap gap-2">
+                            <div class="text-break fw-semibold">@folder</div>
+                            <button class="btn btn-sm btn-outline-primary"
+                                    type="button"
+                                    disabled="@isLoadingFiles"
+                                    @onclick="async () => await EnterFolderAsync(folder)">เปิด</button>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+
+        if (currentFiles.Count == 0)
+        {
+            <div class="alert alert-info" role="alert">โฟลเดอร์นี้ไม่มีไฟล์ PDF</div>
+        }
+        else
+        {
+            <div class="list-group mb-4">
+                @foreach (var file in currentFiles)
+                {
+                    <div class="list-group-item d-flex justify-content-between align-items-center flex-wrap gap-2">
+                        <div class="text-break">@file</div>
+                        <div class="d-flex gap-2">
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="@BuildPdfUrl(selectedLine!, file)"
+                               target="_blank" rel="noopener noreferrer">เปิด</a>
+                            <button class="btn btn-sm btn-primary"
+                                    type="button"
+                                    @onclick="() => PreviewFile(file)">พรีวิว</button>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    }
+}
+
+@if (!string.IsNullOrEmpty(previewFile) && selectedLine is not null)
+{
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <div>
+                <strong>Preview:</strong> @previewFile
+            </div>
+            <div class="d-flex gap-2">
+                <a class="btn btn-sm btn-outline-secondary"
+                   href="@BuildPdfUrl(selectedLine!, previewFile!)"
+                   target="_blank" rel="noopener noreferrer">เปิดในแท็บใหม่</a>
+                <button class="btn btn-sm btn-outline-danger" @onclick="ClosePreview">ปิดพรีวิว</button>
+            </div>
+        </div>
+        <div class="card-body p-0">
+            <iframe src="@BuildPdfUrl(selectedLine!, previewFile!)"
+                    style="width:100%; height:70vh; border:0;"
+                    title="PDF Preview"></iframe>
+        </div>
+    </div>
+}
+
+@code {
+    private static readonly string[] AllLines = ["F1", "F2", "F3"];
+    private const long MaxUploadBytes = 50L * 1024 * 1024;
+
+    private readonly HashSet<string> availableLines = new(StringComparer.OrdinalIgnoreCase);
+    private List<string>? currentFiles;
+    private List<string> currentFolders = new();
+    private List<string> currentPathSegments = new();
+    private string? selectedLine;
+    private string? previewFile;
+    private bool isLoadingLines;
+    private bool isLoadingFiles;
+    private bool isUploadingFile;
+    private bool isCreatingFolder;
+    private string? linesError;
+    private string? filesError;
+    private string? uploadError;
+    private string? uploadSuccess;
+    private string? createFolderError;
+    private string? createFolderSuccess;
+    private IBrowserFile? pendingUpload;
+    private string? pendingFileName;
+    private string? newFolderName = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadFoldersAsync();
+    }
+
+    private async Task LoadFoldersAsync()
+    {
+        try
+        {
+            isLoadingLines = true;
+            linesError = null;
+            var foldersEndpoint = NavManager.ToAbsoluteUri("/api/folders");
+            var folders = await Http.GetFromJsonAsync<List<string>>(foldersEndpoint);
+            availableLines.Clear();
+            if (folders is not null)
+            {
+                foreach (var folder in folders)
+                {
+                    availableLines.Add(folder);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            linesError = $"ไม่สามารถโหลดโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isLoadingLines = false;
+        }
+
+        if (availableLines.Count > 0 && selectedLine is null)
+        {
+            var preferred = AllLines.FirstOrDefault(line => availableLines.Contains(line));
+            if (preferred is not null)
+            {
+                await SelectLine(preferred);
+            }
+        }
+    }
+
+    private async Task SelectLine(string line)
+    {
+        if (!availableLines.Contains(line))
+        {
+            return;
+        }
+
+        selectedLine = line;
+        previewFile = null;
+        currentFiles = null;
+        currentFolders = new List<string>();
+        currentPathSegments = new List<string>();
+        ResetUploadState();
+        ResetFolderCreationState();
+        filesError = null;
+        await LoadFilesAsync(line, Array.Empty<string>());
+    }
+
+    private async Task LoadFilesAsync(string line, IReadOnlyList<string>? pathSegments = null)
+    {
+        var targetSegments = pathSegments is null
+            ? new List<string>(currentPathSegments)
+            : new List<string>(pathSegments);
+
+        currentFiles = null;
+        try
+        {
+            isLoadingFiles = true;
+            filesError = null;
+            var query = BuildPathQuery(targetSegments);
+            var filesEndpoint = NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(line)}{query}");
+            var listing = await Http.GetFromJsonAsync<FolderListingResponse>(filesEndpoint);
+
+            if (listing is null)
+            {
+                currentFolders = new List<string>();
+                currentFiles = new List<string>();
+                currentPathSegments = targetSegments;
+                return;
+            }
+
+            currentFolders = listing.Folders is { } folders
+                ? new List<string>(folders)
+                : new List<string>();
+
+            currentFiles = listing.Files is { } files
+                ? new List<string>(files)
+                : new List<string>();
+
+            currentPathSegments = listing.PathSegments is { } pathList
+                ? new List<string>(pathList)
+                : new List<string>(targetSegments);
+        }
+        catch (Exception ex)
+        {
+            filesError = $"ไม่สามารถโหลดไฟล์ได้: {ex.Message}";
+            currentFolders = new List<string>();
+            currentFiles = new List<string>();
+            currentPathSegments = targetSegments;
+        }
+        finally
+        {
+            isLoadingFiles = false;
+        }
+    }
+
+    private void PreviewFile(string file)
+    {
+        previewFile = file;
+    }
+
+    private void ClosePreview()
+    {
+        previewFile = null;
+    }
+
+    private string BuildPdfUrl(string line, string file)
+    {
+        var baseUrl = $"/pdf/{Uri.EscapeDataString(line)}/{Uri.EscapeDataString(file)}";
+        var query = BuildPathQuery(currentPathSegments);
+        return string.IsNullOrEmpty(query) ? baseUrl : $"{baseUrl}{query}";
+    }
+
+    private string GetCurrentPathDisplay()
+    {
+        if (selectedLine is null)
+        {
+            return string.Empty;
+        }
+
+        return currentPathSegments.Count == 0
+            ? selectedLine
+            : $"{selectedLine}\\{string.Join('\\', currentPathSegments)}";
+    }
+
+    private async Task NavigateToRootAsync()
+    {
+        if (selectedLine is null)
+        {
+            return;
+        }
+
+        previewFile = null;
+        await LoadFilesAsync(selectedLine, Array.Empty<string>());
+    }
+
+    private async Task NavigateToBreadcrumbAsync(int depth)
+    {
+        if (selectedLine is null)
+        {
+            return;
+        }
+
+        if (depth < 0 || depth >= currentPathSegments.Count)
+        {
+            return;
+        }
+
+        previewFile = null;
+        var target = currentPathSegments.Take(depth + 1).ToList();
+        await LoadFilesAsync(selectedLine, target);
+    }
+
+    private async Task EnterFolderAsync(string folder)
+    {
+        if (selectedLine is null || string.IsNullOrWhiteSpace(folder))
+        {
+            return;
+        }
+
+        previewFile = null;
+        var target = new List<string>(currentPathSegments) { folder };
+        await LoadFilesAsync(selectedLine, target);
+    }
+
+    private static string BuildPathQuery(IReadOnlyList<string> segments)
+    {
+        if (segments.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var encoded = string.Join('/', segments.Select(Uri.EscapeDataString));
+        return $"?path={encoded}";
+    }
+
+    private void HandleFileSelected(InputFileChangeEventArgs e)
+    {
+        uploadError = null;
+        uploadSuccess = null;
+        pendingUpload = null;
+        pendingFileName = null;
+
+        var file = e.File;
+        if (file is null)
+        {
+            uploadError = "ไม่พบไฟล์ที่เลือก";
+            return;
+        }
+
+        if (!file.Name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+        {
+            uploadError = "กรุณาเลือกไฟล์ PDF (.pdf)";
+            return;
+        }
+
+        pendingUpload = file;
+        pendingFileName = file.Name;
+    }
+
+    private bool CanUpload => selectedLine is not null && pendingUpload is not null && !isUploadingFile;
+
+    private async Task UploadSelectedFile()
+    {
+        if (!CanUpload || selectedLine is null || pendingUpload is null)
+        {
+            return;
+        }
+
+        uploadError = null;
+        uploadSuccess = null;
+        isUploadingFile = true;
+
+        try
+        {
+            var uploadEndpoint = NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(selectedLine)}/upload{BuildPathQuery(currentPathSegments)}");
+            using var content = new MultipartFormDataContent();
+            var stream = pendingUpload.OpenReadStream(MaxUploadBytes);
+            var streamContent = new StreamContent(stream);
+            streamContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
+            content.Add(streamContent, "file", pendingUpload.Name);
+
+            var response = await Http.PostAsync(uploadEndpoint, content);
+            if (response.IsSuccessStatusCode)
+            {
+                var uploadedName = pendingFileName ?? pendingUpload.Name;
+                uploadSuccess = string.IsNullOrEmpty(uploadedName)
+                    ? "อัปโหลดไฟล์เรียบร้อย"
+                    : $"อัปโหลดไฟล์ {uploadedName} เรียบร้อย";
+                await LoadFilesAsync(selectedLine, currentPathSegments);
+                pendingUpload = null;
+                pendingFileName = null;
+            }
+            else
+            {
+                uploadError = await ExtractErrorMessageAsync(response);
+            }
+        }
+        catch (Exception ex)
+        {
+            uploadError = $"อัปโหลดไม่สำเร็จ: {ex.Message}";
+        }
+        finally
+        {
+            isUploadingFile = false;
+        }
+    }
+
+    private void ResetUploadState()
+    {
+        isUploadingFile = false;
+        uploadError = null;
+        uploadSuccess = null;
+        pendingUpload = null;
+        pendingFileName = null;
+    }
+
+    private bool CanCreateFolder => selectedLine is not null && !string.IsNullOrWhiteSpace(newFolderName) && !isCreatingFolder;
+
+    private async Task CreateFolderAsync()
+    {
+        if (selectedLine is null)
+        {
+            return;
+        }
+
+        var desiredName = newFolderName?.Trim();
+        if (string.IsNullOrWhiteSpace(desiredName))
+        {
+            createFolderError = "กรุณากรอกชื่อโฟลเดอร์";
+            createFolderSuccess = null;
+            return;
+        }
+
+        isCreatingFolder = true;
+        createFolderError = null;
+        createFolderSuccess = null;
+
+        try
+        {
+            var endpoint = NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(selectedLine)}/subfolders{BuildPathQuery(currentPathSegments)}");
+            var response = await Http.PostAsJsonAsync(endpoint, new { name = desiredName });
+
+            if (response.IsSuccessStatusCode)
+            {
+                createFolderSuccess = $"สร้างโฟลเดอร์ {desiredName} เรียบร้อย";
+                newFolderName = string.Empty;
+                await LoadFilesAsync(selectedLine, currentPathSegments);
+            }
+            else
+            {
+                createFolderError = await ExtractErrorMessageAsync(response);
+            }
+        }
+        catch (Exception ex)
+        {
+            createFolderError = $"ไม่สามารถสร้างโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isCreatingFolder = false;
+        }
+    }
+
+    private void ResetFolderCreationState()
+    {
+        isCreatingFolder = false;
+        createFolderError = null;
+        createFolderSuccess = null;
+        newFolderName = string.Empty;
+    }
+
+    private sealed class FolderListingResponse
+    {
+        public List<string> PathSegments { get; set; } = new();
+        public List<string> Folders { get; set; } = new();
+        public List<string> Files { get; set; } = new();
+    }
+
+    private static async Task<string> ExtractErrorMessageAsync(HttpResponseMessage response)
+    {
+        var message = await response.Content.ReadAsStringAsync();
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+
+        if (string.Equals(mediaType, "application/problem+json", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(message);
+                if (doc.RootElement.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
+                {
+                    var detailValue = detail.GetString();
+                    if (!string.IsNullOrWhiteSpace(detailValue))
+                    {
+                        return detailValue!;
+                    }
+                }
+
+                if (doc.RootElement.TryGetProperty("title", out var title) && title.ValueKind == JsonValueKind.String)
+                {
+                    var titleValue = title.GetString();
+                    if (!string.IsNullOrWhiteSpace(titleValue))
+                    {
+                        return titleValue!;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // ignore parsing failures and fall back to the raw message
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            message = $"คำขอไม่สำเร็จ (รหัส {response.StatusCode})";
+        }
+
+        return message;
+    }
+}

--- a/Components/Pages/PdfBrowser.razor
+++ b/Components/Pages/PdfBrowser.razor
@@ -1,16 +1,38 @@
 @page "/pdfs"
 @using System
+@using System.Collections.Generic
+@using System.Linq
 @using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
 @inject HttpClient Http
-@inject NavigationManager Navigation
+@inject NavigationManager NavManager
 
 <h2 class="mb-3">📄 PDF Browser (Local Server)</h2>
 
+<div class="mb-3">
+    <label class="form-label fw-semibold">เลือกโฟลเดอร์</label>
+    <select class="form-select" value="@selectedLine" @onchange="HandleFolderChanged" disabled="@isLoadingFolders">
+        <option value="" disabled>-- เลือกโฟลเดอร์ --</option>
+        @foreach (var line in availableLines)
+        {
+            <option value="@line">@line</option>
+        }
+    </select>
+    @if (!string.IsNullOrEmpty(foldersError))
+    {
+        <div class="alert alert-danger mt-2" role="alert">@foldersError</div>
+    }
+</div>
+
 <div class="row">
-    <div class="col-4">
-        <input class="form-control mb-2" placeholder="ค้นหาไฟล์..." @bind="search" @bind:event="oninput" />
+    <div class="col-12 col-lg-4 mb-3 mb-lg-0">
+        <input class="form-control mb-2"
+               placeholder="ค้นหาไฟล์..."
+               @bind="search"
+               @bind:event="oninput"
+               disabled="@isLoadingFiles" />
         <ul class="list-group" style="max-height: 70vh; overflow:auto;">
-            @if (files is null)
+            @if (isLoadingFiles)
             {
                 <li class="list-group-item">กำลังโหลด...</li>
             }
@@ -22,29 +44,40 @@
             {
                 @foreach (var f in Filtered)
                 {
-                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <button class="btn btn-link p-0" @onclick="() => Select(f.name)">@f.name</button>
-                        <a class="btn btn-sm btn-outline-secondary"
-                           href="@($"/api/pdfs/{Uri.EscapeDataString(f.name)}/download")" target="_blank">ดาวน์โหลด</a>
+                    <li class="list-group-item d-flex justify-content-between align-items-center @(string.Equals(selected, f, StringComparison.Ordinal) ? "active" : string.Empty)">
+                        <span class="flex-grow-1 text-truncate me-3" title="@f">@f</span>
+                        <div class="btn-group" role="group">
+                            <button class="btn btn-sm btn-outline-primary" @onclick="() => Select(f)" disabled="@string.IsNullOrEmpty(selectedLine)">แสดง</button>
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="@(selectedLine is null ? null : BuildPdfUrl(selectedLine, f))"
+                               target="_blank" rel="noopener noreferrer"
+                               aria-disabled="@(selectedLine is null)">เปิด</a>
+                        </div>
                     </li>
                 }
             }
         </ul>
     </div>
 
-    <div class="col-8">
-        @if (!string.IsNullOrEmpty(selected))
+    <div class="col-12 col-lg-8">
+        @if (!string.IsNullOrEmpty(filesError))
+        {
+            <div class="alert alert-danger" role="alert">@filesError</div>
+        }
+        else if (!string.IsNullOrEmpty(selected) && !string.IsNullOrEmpty(selectedLine))
         {
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h5 class="m-0">พรีวิว: @selected</h5>
                 <a class="btn btn-sm btn-primary"
-                   href="@($"/api/pdfs/{Uri.EscapeDataString(selected)}")" target="_blank">เปิดในแท็บใหม่</a>
+                   href="@BuildPdfUrl(selectedLine!, selected)"
+                   target="_blank" rel="noopener noreferrer">เปิดในแท็บใหม่</a>
             </div>
 
             <iframe style="width:100%; height:75vh; border:1px solid #ccc; border-radius:8px;"
-                    src="@($"/api/pdfs/{Uri.EscapeDataString(selected)}")"></iframe>
+                    src="@BuildPdfUrl(selectedLine!, selected)"
+                    title="PDF Preview"></iframe>
         }
-        else
+        else if (!isLoadingFiles)
         {
             <div class="text-muted">เลือกไฟล์ทางซ้ายเพื่อดูพรีวิว</div>
         }
@@ -52,48 +85,121 @@
 </div>
 
 @code {
-    record PdfInfo(string name, long sizeBytes, DateTime modifiedUtc);
-    List<PdfInfo>? files;
+    readonly List<string> availableLines = new();
+    List<string>? files;
+    string? selectedLine;
     string? selected;
+    string? foldersError;
+    string? filesError;
+    bool isLoadingFolders;
+    bool isLoadingFiles;
 
-    string? previewSrc;
-    Guid previewNonce = Guid.Empty;
-    string search = "";
+    string search = string.Empty;
 
-    IEnumerable<PdfInfo> Filtered => (files ?? Enumerable.Empty<PdfInfo>())
-        .Where(f => string.IsNullOrWhiteSpace(search) || f.name.Contains(search, StringComparison.OrdinalIgnoreCase));
+    IEnumerable<string> Filtered => (files ?? Enumerable.Empty<string>())
+        .Where(f => string.IsNullOrWhiteSpace(search) || f.Contains(search, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = Navigation.ToAbsoluteUri("/api/pdfs");
-        files = await Http.GetFromJsonAsync<List<PdfInfo>>(endpoint);
-        selected = files?.FirstOrDefault()?.name;
+        await LoadFoldersAsync();
     }
 
-    void Select(string name) => selected = name;
+    async Task LoadFoldersAsync()
+    {
+        try
+        {
+            isLoadingFolders = true;
+            foldersError = null;
+            var folders = await Http.GetFromJsonAsync<List<string>>(NavManager.ToAbsoluteUri("/api/folders"));
+            availableLines.Clear();
+            if (folders is not null)
+            {
+                foreach (var folder in folders)
+                {
+                    availableLines.Add(folder);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            foldersError = $"ไม่สามารถโหลดโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isLoadingFolders = false;
+        }
+
+        if (availableLines.Count > 0)
+        {
+            var nextLine = GetMatchingLine(selectedLine) ?? availableLines.First();
+            await LoadFilesAsync(nextLine);
+        }
+        else
+        {
+            selectedLine = null;
+            files = new List<string>();
+            selected = null;
+        }
+    }
+
+    async Task LoadFilesAsync(string line)
+    {
+        selectedLine = line;
+        selected = null;
+        filesError = null;
+        try
+        {
+            isLoadingFiles = true;
+            files = await Http.GetFromJsonAsync<List<string>>(NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(line)}"));
+            files ??= new List<string>();
+        }
+        catch (Exception ex)
+        {
+            filesError = $"ไม่สามารถโหลดไฟล์ได้: {ex.Message}";
+            files = new List<string>();
+        }
+        finally
+        {
+            isLoadingFiles = false;
+        }
+
+        var first = files.FirstOrDefault();
+        if (first is not null)
+        {
+            ApplySelection(first, force: true);
+        }
+    }
 
     void Select(string name) => ApplySelection(name);
 
-    string PreviewUrl(string name) => $"/api/pdfs/{Uri.EscapeDataString(name)}";
-
-    string BuildPreviewSource(string name, Guid nonce)
+    async Task HandleFolderChanged(ChangeEventArgs args)
     {
-        var baseUri = Navigation.ToAbsoluteUri(PreviewUrl(name)).ToString();
-        var separator = baseUri.Contains('?') ? '&' : '?';
-        return $"{baseUri}{separator}v={nonce}";
-    }
-
-    string DownloadUrl(string name) => $"{PreviewUrl(name)}/download";
-
-    string GetItemClasses(string name)
-    {
-        var classes = "list-group-item";
-        if (string.Equals(selected, name, StringComparison.Ordinal))
+        var line = args.Value?.ToString();
+        var match = GetMatchingLine(line);
+        if (!string.IsNullOrWhiteSpace(match))
         {
-            classes += " active";
+            await LoadFilesAsync(match);
+            return;
         }
 
-        return classes;
+        selectedLine = null;
+        files = new List<string>();
+        selected = null;
+    }
+
+    static string BuildPdfUrl(string line, string name)
+    {
+        return $"/pdf/{Uri.EscapeDataString(line)}/{Uri.EscapeDataString(name)}";
+    }
+
+    string? GetMatchingLine(string? line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return null;
+        }
+
+        return availableLines.FirstOrDefault(l => string.Equals(l, line, StringComparison.OrdinalIgnoreCase));
     }
 
     bool ApplySelection(string name, bool force = false)
@@ -104,8 +210,6 @@
         }
 
         selected = name;
-        previewNonce = Guid.NewGuid();
-        previewSrc = BuildPreviewSource(name, previewNonce);
         return true;
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,18 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Http.Features;
+
+const long MaxUploadBytes = 50L * 1024 * 1024; // 50 MB upload limit per PDF
+
 var builder = WebApplication.CreateBuilder(args);
 
-// เปิดโหมด Blazor Server
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddHttpClient();
+builder.Services.Configure<FormOptions>(options =>
+{
+    options.MultipartBodyLengthLimit = MaxUploadBytes;
+});
 
 var app = builder.Build();
 
@@ -18,85 +26,525 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseAntiforgery();
 
-// ====== PDF APIs ======
-var pdfRoot = app.Configuration["PdfStorage:Root"]
-              ?? Path.Combine(app.Environment.ContentRootPath, "PDFs");
-Directory.CreateDirectory(pdfRoot);
+// ====== PDF browser configuration ======
+// TODO: Replace the UNC path below with the actual PDF root if it differs in your environment.
+//       Ensure the web process identity has READ/WRITE access on both the share and NTFS ACLs.
+var pdfRoot = builder.Configuration["PdfStorage:Root"]
+              ?? @"\\\\10.192.132.91\\PdfRoot";
 
-// กัน path traversal + บังคับ .pdf
-bool IsSafeFileName(string name)
+if (!Directory.Exists(pdfRoot))
 {
-    if (!name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+    app.Logger.LogWarning("Configured PDF root '{PdfRoot}' is not accessible. Confirm the share path and permissions.", pdfRoot);
+}
+var allowedLines = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+{
+    "F1",
+    "F2",
+    "F3"
+};
+
+static bool IsValidPdfFileName(string fileName)
+{
+    if (string.IsNullOrWhiteSpace(fileName))
     {
         return false;
     }
 
-    if (!string.Equals(Path.GetFileName(name), name, StringComparison.Ordinal))
+    if (!fileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
     {
         return false;
     }
 
-    return name.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+    if (!string.Equals(Path.GetFileName(fileName), fileName, StringComparison.Ordinal))
+    {
+        return false;
+    }
+
+    return fileName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
 }
 
-// 1) รายการไฟล์
-app.MapGet("/api/pdfs", () =>
+static bool IsValidFolderName(string folderName)
 {
-    var files = Directory.EnumerateFiles(pdfRoot, "*.pdf", SearchOption.TopDirectoryOnly)
-                         .Select(full => new
-                         {
-                             name = Path.GetFileName(full),
-                             sizeBytes = new FileInfo(full).Length,
-                             modifiedUtc = File.GetLastWriteTimeUtc(full),
-                         })
-                         .OrderByDescending(f => f.modifiedUtc);
-    return Results.Ok(files);
-});
-
-IResult? ValidatePdfRequest(string name, out string fullPath)
-{
-    fullPath = string.Empty;
-    if (!IsSafeFileName(name))
+    if (string.IsNullOrWhiteSpace(folderName))
     {
-        return Results.BadRequest("invalid file name");
+        return false;
     }
 
-    var candidate = Path.Combine(pdfRoot, name);
+    var trimmed = folderName.Trim();
+    if (trimmed.Length > 100)
+    {
+        return false;
+    }
+
+    if (string.Equals(trimmed, ".", StringComparison.Ordinal) || string.Equals(trimmed, "..", StringComparison.Ordinal))
+    {
+        return false;
+    }
+
+    return trimmed.IndexOfAny(Path.GetInvalidFileNameChars()) < 0
+           && !trimmed.Contains(Path.DirectorySeparatorChar)
+           && !trimmed.Contains(Path.AltDirectorySeparatorChar);
+}
+
+static IReadOnlyList<string> ParsePathSegments(string? rawPath)
+{
+    if (string.IsNullOrWhiteSpace(rawPath))
+    {
+        return Array.Empty<string>();
+    }
+
+    return rawPath
+        .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}
+
+bool TryResolveLine(string line, out string? linePath)
+{
+    linePath = null;
+    if (!allowedLines.Contains(line))
+    {
+        return false;
+    }
+
+    var candidate = Path.Combine(pdfRoot, line);
+    if (!Directory.Exists(candidate))
+    {
+        return false;
+    }
+
+    linePath = candidate;
+    return true;
+}
+
+bool TryResolveDirectory(string line, IReadOnlyList<string> segments, out string? directoryPath, out List<string>? normalizedSegments, out IResult? error)
+{
+    directoryPath = null;
+    normalizedSegments = null;
+    error = null;
+
+    if (!TryResolveLine(line, out var linePath))
+    {
+        error = Results.NotFound("Unknown folder");
+        return false;
+    }
+
+    var currentDirectory = new DirectoryInfo(linePath!);
+    var collected = new List<string>();
+
+    foreach (var segment in segments)
+    {
+        if (!IsValidFolderName(segment))
+        {
+            error = Results.BadRequest("ชื่อโฟลเดอร์ไม่ถูกต้อง");
+            return false;
+        }
+
+        var nextPath = Path.Combine(currentDirectory.FullName, segment);
+        if (!Directory.Exists(nextPath))
+        {
+            error = Results.NotFound("ไม่พบโฟลเดอร์ที่ระบุ");
+            return false;
+        }
+
+        currentDirectory = new DirectoryInfo(nextPath);
+        collected.Add(currentDirectory.Name);
+    }
+
+    directoryPath = currentDirectory.FullName;
+    normalizedSegments = collected;
+    return true;
+}
+
+IResult? TryResolvePdf(string line, IReadOnlyList<string> pathSegments, string file, out string? filePath)
+{
+    filePath = null;
+    if (!IsValidPdfFileName(file))
+    {
+        return Results.BadRequest("Invalid PDF file name");
+    }
+
+    if (!TryResolveDirectory(line, pathSegments, out var directoryPath, out _, out var error))
+    {
+        return error;
+    }
+
+    var candidate = Path.Combine(directoryPath!, file);
     if (!System.IO.File.Exists(candidate))
     {
         return Results.NotFound();
     }
 
-    fullPath = candidate;
+    filePath = candidate;
     return null;
 }
 
-// 2) พรีวิว inline
-app.MapGet("/api/pdfs/{name}", (string name) =>
+static string BuildRelativeFilePath(IReadOnlyList<string> segments, string fileName)
 {
-    if (ValidatePdfRequest(name, out var fullPath) is { } error)
+    if (segments.Count == 0)
+    {
+        return fileName;
+    }
+
+    return string.Join('/', segments) + "/" + fileName;
+}
+
+static string DescribeRelativeTime(DateTime timestampUtc)
+{
+    var now = DateTime.UtcNow;
+    var delta = now - timestampUtc;
+
+    if (delta < TimeSpan.Zero)
+    {
+        delta = TimeSpan.Zero;
+    }
+
+    if (delta.TotalMinutes < 1)
+    {
+        return "เมื่อสักครู่";
+    }
+
+    if (delta.TotalHours < 1)
+    {
+        return $"ประมาณ {Math.Floor(delta.TotalMinutes)} นาทีที่แล้ว";
+    }
+
+    if (delta.TotalDays < 1)
+    {
+        return $"ประมาณ {Math.Floor(delta.TotalHours)} ชั่วโมงที่แล้ว";
+    }
+
+    if (delta.TotalDays < 7)
+    {
+        return $"ประมาณ {Math.Floor(delta.TotalDays)} วันที่แล้ว";
+    }
+
+    if (delta.TotalDays < 30)
+    {
+        return $"ประมาณ {Math.Floor(delta.TotalDays / 7)} สัปดาห์ที่แล้ว";
+    }
+
+    if (delta.TotalDays < 365)
+    {
+        return $"ประมาณ {Math.Floor(delta.TotalDays / 30)} เดือนที่แล้ว";
+    }
+
+    return $"ประมาณ {Math.Floor(delta.TotalDays / 365)} ปีที่แล้ว";
+}
+
+static string BuildBranchStatusMessage(DateTime? lastModifiedUtc, int totalPdfCount, int childCount)
+{
+    if (totalPdfCount == 0)
+    {
+        return childCount > 0
+            ? "ยังไม่มีไฟล์ PDF ในกิ่งนี้"
+            : "ยังไม่มีไฟล์ PDF";
+    }
+
+    if (lastModifiedUtc is null)
+    {
+        return "มีไฟล์ PDF แต่ไม่พบข้อมูลการอัปเดต";
+    }
+
+    return $"อัปเดตล่าสุด {DescribeRelativeTime(lastModifiedUtc.Value)}";
+}
+
+BranchEditStatus BuildBranchStatus(DirectoryInfo directory, IReadOnlyList<string> segments)
+{
+    List<FileInfo> pdfFiles;
+    try
+    {
+        pdfFiles = directory.EnumerateFiles("*.pdf", SearchOption.TopDirectoryOnly)
+            .Where(file => IsValidPdfFileName(file.Name))
+            .OrderByDescending(file => file.LastWriteTimeUtc)
+            .ToList();
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        return new BranchEditStatus(
+            directory.Name,
+            segments.ToList(),
+            PdfCount: 0,
+            TotalPdfCount: 0,
+            LastModifiedUtc: null,
+            Status: "ไม่สามารถอ่านไฟล์ในกิ่งนี้ได้",
+            RecentFiles: Array.Empty<FileEditStatus>(),
+            Children: Array.Empty<BranchEditStatus>(),
+            ErrorMessage: $"ไม่สามารถอ่านไฟล์: {ex.Message}");
+    }
+
+    var recentFiles = pdfFiles
+        .Take(5)
+        .Select(file => new FileEditStatus(
+            file.Name,
+            file.LastWriteTimeUtc,
+            file.Length,
+            BuildRelativeFilePath(segments, file.Name)))
+        .ToList();
+
+    var children = new List<BranchEditStatus>();
+    string? childEnumerationError = null;
+
+    try
+    {
+        foreach (var childDirectory in directory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
+                     .Where(dir => IsValidFolderName(dir.Name))
+                     .OrderBy(dir => dir.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            var childSegments = new List<string>(segments) { childDirectory.Name };
+            children.Add(BuildBranchStatus(childDirectory, childSegments));
+        }
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        childEnumerationError = $"ไม่สามารถอ่านโฟลเดอร์ย่อย: {ex.Message}";
+    }
+
+    var pdfCount = pdfFiles.Count;
+    var totalPdfCount = pdfCount + children.Sum(child => child.TotalPdfCount);
+
+    DateTime? lastModified = pdfFiles.Count > 0
+        ? pdfFiles.Max(file => file.LastWriteTimeUtc)
+        : (DateTime?)null;
+
+    foreach (var child in children)
+    {
+        if (child.LastModifiedUtc is { } childLast && (lastModified is null || childLast > lastModified))
+        {
+            lastModified = childLast;
+        }
+    }
+
+    var status = !string.IsNullOrEmpty(childEnumerationError)
+        ? childEnumerationError!
+        : BuildBranchStatusMessage(lastModified, totalPdfCount, children.Count);
+
+    return new BranchEditStatus(
+        directory.Name,
+        segments.ToList(),
+        pdfCount,
+        totalPdfCount,
+        lastModified,
+        status,
+        recentFiles,
+        children,
+        childEnumerationError);
+}
+
+LineEditStatus BuildLineEditStatus(string line, string pdfRootPath)
+{
+    var lineDirectory = Path.Combine(pdfRootPath, line);
+
+    if (!Directory.Exists(lineDirectory))
+    {
+        return new LineEditStatus(line, null, "ไม่พบโฟลเดอร์สำหรับไลน์นี้บนเซิร์ฟเวอร์");
+    }
+
+    try
+    {
+        var directoryInfo = new DirectoryInfo(lineDirectory);
+        var rootBranch = BuildBranchStatus(directoryInfo, Array.Empty<string>());
+        return new LineEditStatus(line, rootBranch, null);
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        return new LineEditStatus(line, null, $"ไม่สามารถอ่านข้อมูลได้: {ex.Message}");
+    }
+}
+
+app.MapGet("/api/folders", () =>
+{
+    try
+    {
+        var existing = allowedLines
+            .Select(line => new { line, path = Path.Combine(pdfRoot, line) })
+            .Where(x => Directory.Exists(x.path))
+            .Select(x => x.line)
+            .OrderBy(line => line)
+            .ToList();
+
+        return Results.Ok(existing);
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to enumerate folders under {PdfRoot}", pdfRoot);
+        return Results.Problem("ไม่สามารถอ่านรายการโฟลเดอร์ได้ กรุณาตรวจสอบการแชร์และสิทธิ์การเข้าถึง");
+    }
+});
+
+app.MapGet("/api/folders/{line}", (string line, HttpRequest request) =>
+{
+    var pathSegments = ParsePathSegments(request.Query["path"]);
+    if (!TryResolveDirectory(line, pathSegments, out var directoryPath, out var normalizedSegments, out var error))
+    {
+        return error ?? Results.NotFound();
+    }
+
+    try
+    {
+        var folders = Directory.EnumerateDirectories(directoryPath!, "*", SearchOption.TopDirectoryOnly)
+            .Select(Path.GetFileName)
+            .Where(name => name is not null && IsValidFolderName(name))
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .Select(name => name!)
+            .ToList();
+
+        var files = Directory.EnumerateFiles(directoryPath!, "*.pdf", SearchOption.TopDirectoryOnly)
+            .Where(path => IsValidPdfFileName(Path.GetFileName(path)))
+            .Select(Path.GetFileName)
+            .Where(name => name is not null)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .Select(name => name!)
+            .ToList();
+
+        return Results.Ok(new FolderListing(line, normalizedSegments ?? new List<string>(), folders, files));
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to enumerate files for {Line} in {PdfRoot}", line, pdfRoot);
+        return Results.Problem("ไม่สามารถอ่านไฟล์ในโฟลเดอร์ที่เลือกได้ กรุณาตรวจสอบสิทธิ์การเข้าถึง");
+    }
+});
+
+app.MapGet("/pdf/{line}/{file}", (string line, string file, HttpRequest request) =>
+{
+    var pathSegments = ParsePathSegments(request.Query["path"]);
+
+    if (TryResolvePdf(line, pathSegments, file, out var filePath) is { } error)
     {
         return error;
     }
 
-    return Results.File(fullPath, "application/pdf", enableRangeProcessing: true);
+    try
+    {
+        var stream = System.IO.File.OpenRead(filePath!);
+        return Results.File(stream, MediaTypeNames.Application.Pdf, enableRangeProcessing: true);
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to open PDF {File} for line {Line}", file, line);
+        return Results.Problem("ไม่สามารถเปิดไฟล์ PDF ได้ กรุณาตรวจสอบการแชร์และสิทธิ์การเข้าถึง");
+    }
 });
 
-// 3) ดาวน์โหลด (บังคับแนบไฟล์)
-app.MapGet("/api/pdfs/{name}/download", (string name) =>
+app.MapGet("/api/edit-status", () =>
 {
-    if (ValidatePdfRequest(name, out var fullPath) is { } error)
+    var statuses = allowedLines
+        .OrderBy(line => line, StringComparer.OrdinalIgnoreCase)
+        .Select(line => BuildLineEditStatus(line, pdfRoot))
+        .ToList();
+
+    return Results.Ok(statuses);
+});
+
+app.MapPost("/api/folders/{line}/upload", async (string line, HttpRequest request) =>
+{
+    var pathSegments = ParsePathSegments(request.Query["path"]);
+    if (!TryResolveDirectory(line, pathSegments, out var directoryPath, out _, out var pathError))
     {
-        return error;
+        return pathError ?? Results.NotFound("Unknown folder");
     }
 
-    var stream = System.IO.File.OpenRead(fullPath);
-    return Results.File(stream, "application/pdf", fileDownloadName: name, enableRangeProcessing: true);
-});
-// ====== /PDF APIs ======
+    if (!request.HasFormContentType)
+    {
+        return Results.BadRequest("ต้องเป็น multipart/form-data");
+    }
 
-// NOTE: เปลี่ยน BlazorPdfApp เป็นชื่อ namespace โปรเจกต์คุณถ้าไม่ตรง
+    try
+    {
+        var form = await request.ReadFormAsync();
+        var formFile = form.Files.GetFile("file");
+
+        if (formFile is null || formFile.Length == 0)
+        {
+            return Results.BadRequest("ไม่พบไฟล์หรือไฟล์ว่าง");
+        }
+
+        var originalName = Path.GetFileName(formFile.FileName);
+        if (!IsValidPdfFileName(originalName))
+        {
+            return Results.BadRequest("รองรับเฉพาะไฟล์ .pdf เท่านั้น");
+        }
+
+        if (formFile.Length > MaxUploadBytes)
+        {
+            return Results.BadRequest($"ไฟล์มีขนาดเกิน {MaxUploadBytes / (1024 * 1024)} MB");
+        }
+
+        var destination = Path.Combine(directoryPath!, originalName);
+        if (System.IO.File.Exists(destination))
+        {
+            return Results.Conflict("ไฟล์นี้มีอยู่แล้ว");
+        }
+
+        await using var readStream = formFile.OpenReadStream();
+        await using var writeStream = new FileStream(destination, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        await readStream.CopyToAsync(writeStream);
+
+        return Results.Ok(new { file = originalName, path = pathSegments });
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to upload PDF to {Line}", line);
+        return Results.Problem("ไม่สามารถอัปโหลดไฟล์ได้ กรุณาตรวจสอบสิทธิ์การเข้าถึง");
+    }
+});
+
+app.MapPost("/api/folders/{line}/subfolders", async (string line, HttpContext context) =>
+{
+    var pathSegments = ParsePathSegments(context.Request.Query["path"]);
+    if (!TryResolveDirectory(line, pathSegments, out var directoryPath, out _, out var error))
+    {
+        return error ?? Results.NotFound("Unknown folder");
+    }
+
+    CreateFolderRequest? request;
+    try
+    {
+        request = await context.Request.ReadFromJsonAsync<CreateFolderRequest>();
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException or System.Text.Json.JsonException)
+    {
+        app.Logger.LogWarning(ex, "Invalid folder creation payload for line {Line}", line);
+        return Results.BadRequest("รูปแบบคำขอไม่ถูกต้อง");
+    }
+
+    var name = request?.Name?.Trim();
+    if (string.IsNullOrWhiteSpace(name))
+    {
+        return Results.BadRequest("กรุณาระบุชื่อโฟลเดอร์");
+    }
+
+    if (!IsValidFolderName(name))
+    {
+        return Results.BadRequest("ชื่อโฟลเดอร์ไม่ถูกต้อง");
+    }
+
+    var targetPath = Path.Combine(directoryPath!, name);
+
+    if (Directory.Exists(targetPath))
+    {
+        return Results.Conflict("มีโฟลเดอร์ชื่อนี้อยู่แล้ว");
+    }
+
+    try
+    {
+        Directory.CreateDirectory(targetPath);
+        return Results.Ok(new { folder = name, path = pathSegments });
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+    {
+        app.Logger.LogError(ex, "Failed to create subfolder {Folder} for line {Line}", name, line);
+        return Results.Problem("ไม่สามารถสร้างโฟลเดอร์ได้ กรุณาตรวจสอบสิทธิ์การเข้าถึง");
+    }
+});
+// ====== /PDF browser configuration ======
+
 app.MapRazorComponents<BlazorPdfApp.Components.App>()
    .AddInteractiveServerRenderMode();
 
 app.Run();
+
+internal sealed record FolderListing(string Line, IReadOnlyList<string> PathSegments, IReadOnlyList<string> Folders, IReadOnlyList<string> Files);
+internal sealed record CreateFolderRequest(string? Name);
+internal sealed record LineEditStatus(string Line, BranchEditStatus? Root, string? ErrorMessage);
+internal sealed record BranchEditStatus(string Name, IReadOnlyList<string> PathSegments, int PdfCount, int TotalPdfCount, DateTime? LastModifiedUtc, string Status, IReadOnlyList<FileEditStatus> RecentFiles, IReadOnlyList<BranchEditStatus> Children, string? ErrorMessage);
+internal sealed record FileEditStatus(string FileName, DateTime LastModifiedUtc, long SizeBytes, string RelativePath);

--- a/appsettings.json
+++ b/appsettings.json
@@ -2,6 +2,6 @@
   "Logging": { "LogLevel": { "Default": "Information", "Microsoft.AspNetCore": "Warning" } },
   "AllowedHosts": "*",
   "PdfStorage": {
-    "Root": "D:\\LocalShare\\PDFs"
+    "Root": "\\\\10.192.132.91\\PdfRoot"
   }
 }


### PR DESCRIPTION
## Summary
- add helper routines and a new `/api/edit-status` endpoint that compiles branch-style PDF status metadata from the configured share
- build an Edit page that consumes the endpoint and displays branch hierarchies, last updates, and recent files with refresh controls

## Testing
- not run (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e35fcdd080832f91e767418ec9afdc