### PR TITLE
Prioritize exact search matches on edit dashboard

### DIFF
--- a/Components/Pages/Edit.razor
+++ b/Components/Pages/Edit.razor
@@ -1,0 +1,1030 @@
+@page "/edit"
+@using System
+@using System.Net.Http.Json
+@using System.Linq
+@inject HttpClient Http
+@inject NavigationManager NavManager
+
+<PageTitle>สถานะแก้ไขเอกสาร</PageTitle>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center align-items-start gap-2 mb-4">
+    <h1 class="mb-0">สถานะแก้ไขเอกสาร</h1>
+    <button class="btn btn-outline-secondary" @onclick="RefreshAsync" disabled="@isLoading">
+        @if (isLoading)
+        {
+            <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+        }
+        <span>รีเฟรช</span>
+    </button>
+</div>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <ul class="nav nav-tabs search-tabs mb-3" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button type="button"
+                        role="tab"
+                        class="@GetTabButtonClass(SearchTab.Folder)"
+                        @onclick="() => SetSearchTab(SearchTab.Folder)"
+                        aria-selected="@(activeTab == SearchTab.Folder)">
+                    ค้นหาโฟลเดอร์
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button type="button"
+                        role="tab"
+                        class="@GetTabButtonClass(SearchTab.Document)"
+                        @onclick="() => SetSearchTab(SearchTab.Document)"
+                        aria-selected="@(activeTab == SearchTab.Document)">
+                    ค้นหาเอกสาร
+                </button>
+            </li>
+        </ul>
+
+        <div class="row g-2 align-items-center mb-3">
+            <div class="col-12 col-md-6">
+                <div class="input-group">
+                    <span class="input-group-text">🔍</span>
+                    <input class="form-control"
+                           placeholder="พิมพ์เพื่อค้นหา..."
+                           @bind-value="searchTerm"
+                           @bind-value:event="oninput"
+                           aria-label="ค้นหา" />
+                </div>
+            </div>
+            <div class="col-12 col-md-6 text-md-end text-muted small">
+                @if (activeTab == SearchTab.Folder)
+                {
+                    <span>ผลลัพธ์ทั้งหมด: @GetFolderResultCount()</span>
+                }
+                else
+                {
+                    <span>ผลลัพธ์ทั้งหมด: @GetDocumentResultCount()</span>
+                }
+            </div>
+        </div>
+
+        <div class="search-results">
+            @if (string.IsNullOrWhiteSpace(searchTerm))
+            {
+                <div class="text-muted">พิมพ์คำค้นเพื่อค้นหาโฟลเดอร์หรือเอกสาร</div>
+            }
+            else if (activeTab == SearchTab.Folder)
+            {
+                var results = FilteredFolderResults.ToList();
+                if (results.Count == 0)
+                {
+                    <div class="text-muted">ไม่พบโฟลเดอร์ที่ตรงกับ "@searchTerm"</div>
+                }
+                else
+                {
+                    <div class="list-group list-group-flush">
+                        @foreach (var result in results)
+                        {
+                            <div class="list-group-item d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
+                                <div>
+                                    <div class="fw-semibold">@result.DisplayName</div>
+                                    <div class="small text-muted">@result.DisplayPath</div>
+                                </div>
+                                <div class="d-flex flex-wrap gap-2 text-muted small">
+                                    <span>ไฟล์ในกิ่ง: @result.PdfCount</span>
+                                    <span>ไฟล์รวม: @result.TotalPdfCount</span>
+                                    <span>อัปเดต: @FormatDate(result.LastModifiedUtc)</span>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+            }
+            else
+            {
+                var results = FilteredDocumentResults.ToList();
+                if (results.Count == 0)
+                {
+                    <div class="text-muted">ไม่พบเอกสารที่ตรงกับ "@searchTerm"</div>
+                }
+                else
+                {
+                    <div class="list-group list-group-flush">
+                        @foreach (var result in results)
+                        {
+                            <div class="list-group-item d-flex flex-column gap-1">
+                                <div class="d-flex justify-content-between flex-wrap gap-2 align-items-start">
+                                    <div>
+                                        <div class="fw-semibold">@result.BaseName</div>
+                                        <div class="small text-muted">@result.DisplayPath</div>
+                                    </div>
+                                    <div class="text-muted small text-end">
+                                        <div>เวอร์ชันทั้งหมด: @result.VersionCount</div>
+                                        @if (result.LatestDivision.HasValue)
+                                        {
+                                            <div>เวอร์ชันล่าสุด: Division @result.LatestDivision.Value.ToString("D2")</div>
+                                        }
+                                        <div>อัปเดต: @FormatDate(result.LatestUploadedUtc)</div>
+                                    </div>
+                                </div>
+                                @if (!string.IsNullOrWhiteSpace(result.LatestComment))
+                                {
+                                    <div class="badge bg-light text-dark align-self-start">หมายเหตุล่าสุด: @result.LatestComment</div>
+                                }
+                            </div>
+                        }
+                    </div>
+                }
+            }
+        </div>
+    </div>
+</div>
+
+<style>
+    .search-tabs .nav-item button {
+        border: none;
+        border-bottom: 2px solid transparent;
+        background: none;
+        padding: 0.5rem 1rem;
+        font-weight: 500;
+        color: var(--bs-secondary, #6c757d);
+        cursor: pointer;
+    }
+
+    .search-tabs .nav-item button.active {
+        color: var(--bs-primary, #0d6efd);
+        border-bottom: 2px solid var(--bs-primary, #0d6efd);
+    }
+
+    .search-results .list-group-item {
+        border-left: none;
+        border-right: none;
+    }
+
+    .search-results .list-group-item:first-child {
+        border-top: none;
+    }
+
+    .search-results .list-group-item:last-child {
+        border-bottom: none;
+    }
+
+    .branch-tree {
+        position: relative;
+        padding-left: 0.5rem;
+    }
+
+    .branch-node {
+        position: relative;
+    }
+
+    .branch-card {
+        position: relative;
+        background-color: #ffffff;
+        border-radius: 0.85rem;
+        border: 1px solid var(--bs-border-color, #dee2e6);
+        box-shadow: 0 0.25rem 0.5rem rgba(15, 23, 42, 0.08);
+        margin-left: 1.5rem;
+        margin-bottom: 1.25rem;
+        padding: 1.25rem;
+    }
+
+    .branch-card::before {
+        content: '';
+        position: absolute;
+        left: -1.05rem;
+        top: 1.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 999px;
+        background-color: var(--bs-primary, #0d6efd);
+        box-shadow: 0 0 0 4px #ffffff;
+    }
+
+    .branch-card::after {
+        content: '';
+        position: absolute;
+        left: -1.5rem;
+        top: 1.65rem;
+        width: 1.5rem;
+        height: 2px;
+        background-color: var(--bs-border-color, #d0d7de);
+    }
+
+    .branch-card.latest {
+        border-color: rgba(255, 193, 7, 0.45);
+        box-shadow: 0 0.35rem 0.75rem rgba(255, 193, 7, 0.25);
+    }
+
+    .branch-card.latest::before {
+        background-color: var(--bs-warning, #ffc107);
+    }
+
+    .branch-card.latest::after {
+        background-color: rgba(255, 193, 7, 0.5);
+    }
+
+    .branch-node.depth-0 > .branch-card {
+        border-left: 4px solid var(--bs-primary, #0d6efd);
+        margin-left: 0.75rem;
+    }
+
+    .branch-node.depth-0 > .branch-card::before {
+        left: -0.8rem;
+        top: 1.5rem;
+        background-color: var(--bs-success, #198754);
+    }
+
+    .branch-node.depth-0 > .branch-card::after {
+        display: none;
+    }
+
+    .branch-children {
+        position: relative;
+        margin-left: 2rem;
+        padding-left: 1.5rem;
+        border-left: 2px solid var(--bs-border-color, #d0d7de);
+    }
+
+    .branch-title {
+        font-size: 1.05rem;
+    }
+
+    .branch-badge {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .branch-metrics > div {
+        background-color: rgba(13, 110, 253, 0.08);
+        border-radius: 0.65rem;
+        padding: 0.4rem 0.75rem;
+        color: var(--bs-primary, #0d6efd);
+        font-weight: 500;
+    }
+
+    .branch-metrics > div:nth-child(2) {
+        background-color: rgba(25, 135, 84, 0.08);
+        color: var(--bs-success, #198754);
+    }
+
+    .branch-metrics > div:nth-child(3) {
+        background-color: rgba(108, 117, 125, 0.1);
+        color: var(--bs-secondary, #6c757d);
+    }
+
+    .branch-recent span {
+        display: inline-block;
+        margin-right: 0.25rem;
+    }
+
+    .branch-recent span + span::before {
+        content: '•';
+        margin-right: 0.25rem;
+        color: var(--bs-secondary, #6c757d);
+    }
+
+    .document-timeline {
+        position: relative;
+        background-color: #f8f9fa;
+        border-radius: 1rem;
+        border: 1px solid var(--bs-border-color, #dee2e6);
+        padding: 1.25rem 1.5rem;
+    }
+
+    .document-name {
+        font-size: 1rem;
+    }
+
+    .version-timeline {
+        position: relative;
+        margin-left: 0.35rem;
+        padding-left: 1.5rem;
+        border-left: 2px solid var(--bs-border-color, #d0d7de);
+    }
+
+    .version-node {
+        position: relative;
+        margin-bottom: 1.15rem;
+    }
+
+    .version-node:last-child {
+        margin-bottom: 0;
+    }
+
+    .version-node::before {
+        content: '';
+        position: absolute;
+        left: -1.05rem;
+        top: 0.75rem;
+        width: 0.75rem;
+        height: 0.75rem;
+        border-radius: 50%;
+        background-color: var(--bs-primary, #0d6efd);
+        box-shadow: 0 0 0 4px #ffffff;
+    }
+
+    .version-node.latest::before {
+        background-color: var(--bs-success, #198754);
+    }
+
+    .version-content {
+        background-color: #ffffff;
+        border-radius: 0.85rem;
+        border: 1px solid var(--bs-border-color, #dee2e6);
+        padding: 0.9rem 1.1rem;
+        box-shadow: 0 0.25rem 0.5rem rgba(15, 23, 42, 0.05);
+    }
+
+    .version-node.latest .version-content {
+        border-color: rgba(25, 135, 84, 0.35);
+        box-shadow: 0 0.3rem 0.6rem rgba(25, 135, 84, 0.2);
+        background-color: rgba(25, 135, 84, 0.08);
+    }
+
+    .version-comment {
+        margin-top: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.65rem;
+        background-color: rgba(13, 110, 253, 0.08);
+        color: var(--bs-body-color, #212529);
+        font-size: 0.9rem;
+        line-height: 1.4;
+    }
+
+    @@media (max-width: 767.98px) {
+        .branch-children {
+            border-left: none;
+        }
+
+        .branch-card {
+            margin-left: 0;
+        }
+
+        .branch-card::before {
+            left: -0.4rem;
+        }
+
+        .branch-card::after {
+            display: none;
+        }
+
+        .document-timeline {
+            padding: 1rem;
+        }
+
+        .version-timeline {
+            margin-left: 0;
+            padding-left: 1.1rem;
+        }
+
+        .version-node::before {
+            left: -0.85rem;
+        }
+    }
+</style>
+
+@if (!string.IsNullOrEmpty(errorMessage))
+{
+    <div class="alert alert-danger" role="alert">@errorMessage</div>
+}
+else if (isLoading)
+{
+    <div class="text-muted">กำลังโหลดสถานะการแก้ไข...</div>
+}
+else if (lineStatuses is null || lineStatuses.Count == 0)
+{
+    <div class="alert alert-info" role="alert">ยังไม่มีข้อมูลสถานะการแก้ไข</div>
+}
+else
+{
+    foreach (var line in lineStatuses)
+    {
+        <div class="card mb-4 shadow-sm">
+            <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+                <div class="fs-5 fw-semibold">@line.Line</div>
+                @if (!string.IsNullOrEmpty(line.ErrorMessage))
+                {
+                    <span class="badge bg-danger">ไม่สามารถอ่านข้อมูล</span>
+                }
+                else if (line.Root is not null)
+                {
+                    <span class="badge bg-primary">@line.Root.Status</span>
+                }
+            </div>
+            <div class="card-body">
+                @if (!string.IsNullOrEmpty(line.ErrorMessage))
+                {
+                    <div class="alert alert-danger mb-0">@line.ErrorMessage</div>
+                }
+                else if (line.Root is null)
+                {
+                    <div class="text-muted">ไม่มีข้อมูลสถานะสำหรับโฟลเดอร์นี้</div>
+                }
+                else
+                {
+                    <div class="row g-3 mb-3">
+                        <div class="col-12 col-md-4">
+                            <div class="text-muted text-uppercase small">จำนวนไฟล์ทั้งหมด</div>
+                            <div class="fw-semibold">@line.Root.TotalPdfCount</div>
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <div class="text-muted text-uppercase small">อัปเดตล่าสุด</div>
+                            <div class="fw-semibold">@FormatDate(line.Root.LastModifiedUtc)</div>
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <div class="text-muted text-uppercase small">สถานะ</div>
+                            <div class="fw-semibold">@line.Root.Status</div>
+                        </div>
+                    </div>
+
+                    <div class="branch-tree mt-3">
+                        @RenderBranchNode(line.Root, 0, isLatest: true)
+                    </div>
+                }
+            </div>
+        </div>
+    }
+}
+
+@code {
+    private List<LineEditStatusResponse>? lineStatuses;
+    private bool isLoading = true;
+    private string? errorMessage;
+    private SearchTab activeTab = SearchTab.Folder;
+    private string searchTerm = string.Empty;
+    private readonly List<FolderSearchResult> folderIndex = new();
+    private readonly List<DocumentSearchResult> documentIndex = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStatusesAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        await LoadStatusesAsync();
+    }
+
+    private async Task LoadStatusesAsync()
+    {
+        try
+        {
+            isLoading = true;
+            errorMessage = null;
+
+            var endpoint = NavManager.ToAbsoluteUri("/api/edit-status");
+            var result = await Http.GetFromJsonAsync<List<LineEditStatusResponse>>(endpoint);
+            lineStatuses = (result ?? new List<LineEditStatusResponse>())
+                .OrderByDescending(l => l.Root?.LastModifiedUtc ?? DateTime.MinValue)
+                .ThenBy(l => l.Line, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+            RebuildSearchIndexes();
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"ไม่สามารถโหลดสถานะแก้ไขได้: {ex.Message}";
+            lineStatuses = null;
+            folderIndex.Clear();
+            documentIndex.Clear();
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private IEnumerable<FolderSearchResult> FilteredFolderResults
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(searchTerm))
+            {
+                return folderIndex;
+            }
+
+            var term = searchTerm.Trim();
+            return folderIndex
+                .Select(f => new { Item = f, Rank = CalculateFolderMatchRank(f, term) })
+                .Where(entry => entry.Rank < int.MaxValue)
+                .OrderBy(entry => entry.Rank)
+                .ThenByDescending(entry => entry.Item.LastModifiedUtc ?? DateTime.MinValue)
+                .ThenBy(entry => entry.Item.DisplayPath, StringComparer.CurrentCultureIgnoreCase)
+                .Select(entry => entry.Item);
+        }
+    }
+
+    private IEnumerable<DocumentSearchResult> FilteredDocumentResults
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(searchTerm))
+            {
+                return documentIndex;
+            }
+
+            var term = searchTerm.Trim();
+            return documentIndex
+                .Select(d => new { Item = d, Rank = CalculateDocumentMatchRank(d, term) })
+                .Where(entry => entry.Rank < int.MaxValue)
+                .OrderBy(entry => entry.Rank)
+                .ThenByDescending(entry => entry.Item.LatestUploadedUtc ?? DateTime.MinValue)
+                .ThenBy(entry => entry.Item.DisplayPath, StringComparer.CurrentCultureIgnoreCase)
+                .Select(entry => entry.Item);
+        }
+    }
+
+    private void SetSearchTab(SearchTab tab) => activeTab = tab;
+
+    private string GetTabButtonClass(SearchTab tab)
+        => tab == activeTab ? "nav-link active" : "nav-link";
+
+    private int GetFolderResultCount()
+    {
+        if (string.IsNullOrWhiteSpace(searchTerm))
+        {
+            return folderIndex.Count;
+        }
+
+        var term = searchTerm.Trim();
+        return folderIndex.Count(f => CalculateFolderMatchRank(f, term) < int.MaxValue);
+    }
+
+    private int GetDocumentResultCount()
+    {
+        if (string.IsNullOrWhiteSpace(searchTerm))
+        {
+            return documentIndex.Count;
+        }
+
+        var term = searchTerm.Trim();
+        return documentIndex.Count(d => CalculateDocumentMatchRank(d, term) < int.MaxValue);
+    }
+
+    private static int CalculateFolderMatchRank(FolderSearchResult folder, string term)
+    {
+        var ranks = new[]
+        {
+            CalculateMatchRank(term, folder.DisplayName),
+            CalculateMatchRank(term, folder.DisplayPath)
+        };
+
+        return ranks.Min();
+    }
+
+    private static int CalculateDocumentMatchRank(DocumentSearchResult document, string term)
+    {
+        var ranks = new List<int>
+        {
+            CalculateMatchRank(term, document.BaseName),
+            CalculateMatchRank(term, document.DisplayPath)
+        };
+
+        if (!string.IsNullOrWhiteSpace(document.LatestComment) && document.LatestComment.Contains(term, StringComparison.OrdinalIgnoreCase))
+        {
+            ranks.Add(3);
+        }
+        else
+        {
+            ranks.Add(int.MaxValue);
+        }
+
+        return ranks.Min();
+    }
+
+    private static int CalculateMatchRank(string term, string? candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return int.MaxValue;
+        }
+
+        if (string.Equals(candidate, term, StringComparison.OrdinalIgnoreCase))
+        {
+            return 0;
+        }
+
+        if (candidate.StartsWith(term, StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        if (candidate.Contains(term, StringComparison.OrdinalIgnoreCase))
+        {
+            return 2;
+        }
+
+        return int.MaxValue;
+    }
+
+    private void RebuildSearchIndexes()
+    {
+        folderIndex.Clear();
+        documentIndex.Clear();
+
+        if (lineStatuses is null)
+        {
+            return;
+        }
+
+        foreach (var line in lineStatuses)
+        {
+            if (line.Root is null)
+            {
+                continue;
+            }
+
+            IndexBranch(line.Line, line.Root, Array.Empty<string>());
+        }
+    }
+
+    private void IndexBranch(string line, BranchEditStatusResponse branch, IReadOnlyList<string> parentSegments)
+    {
+        var segments = parentSegments.ToList();
+        if (!string.IsNullOrWhiteSpace(branch.Name))
+        {
+            var isRoot = parentSegments.Count == 0 && string.Equals(branch.Name, line, StringComparison.OrdinalIgnoreCase);
+            if (!isRoot)
+            {
+                segments.Add(branch.Name);
+            }
+        }
+
+        var displaySegments = new List<string> { line };
+        displaySegments.AddRange(segments);
+        var displayPath = string.Join(" / ", displaySegments);
+        var displayName = segments.Count > 0 ? segments[^1] : line;
+
+        folderIndex.Add(new FolderSearchResult
+        {
+            Line = line,
+            DisplayName = displayName,
+            DisplayPath = displayPath,
+            PdfCount = branch.PdfCount,
+            TotalPdfCount = branch.TotalPdfCount,
+            LastModifiedUtc = branch.LastModifiedUtc
+        });
+
+        foreach (var document in branch.Documents ?? Enumerable.Empty<DocumentTimelineResponse>())
+        {
+            var latest = document.Versions
+                .OrderByDescending(v => v.UploadedUtc)
+                .ThenByDescending(v => v.Division)
+                .FirstOrDefault();
+
+            var baseName = document.BaseName ?? string.Empty;
+            documentIndex.Add(new DocumentSearchResult
+            {
+                Line = line,
+                BaseName = baseName,
+                DisplayPath = string.Join(" / ", displaySegments.Append(baseName)),
+                VersionCount = document.Versions.Count,
+                LatestUploadedUtc = latest?.UploadedUtc,
+                LatestDivision = latest?.Division,
+                LatestComment = latest?.Comment ?? string.Empty
+            });
+        }
+
+        foreach (var child in branch.Children)
+        {
+            IndexBranch(line, child, segments);
+        }
+    }
+
+    private RenderFragment RenderBranchNode(BranchEditStatusResponse branch, int depth, bool isLatest = false)
+    {
+        return builder =>
+        {
+            var seq = 0;
+            var orderedChildren = OrderBranches(branch.Children);
+            var orderedDocuments = (branch.Documents ?? new List<DocumentTimelineResponse>())
+                .OrderByDescending(d => d.LatestUploadedUtc ?? DateTime.MinValue)
+                .ThenBy(d => d.BaseName, StringComparer.CurrentCultureIgnoreCase)
+                .ToList();
+            var recentFiles = branch.RecentFiles
+                .OrderByDescending(f => f.LastModifiedUtc)
+                .Take(3)
+                .ToList();
+
+            var nodeClasses = $"branch-node depth-{depth}";
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", nodeClasses);
+
+            var cardClasses = depth == 0 ? "branch-card root-branch" : "branch-card";
+            if (isLatest && depth > 0)
+            {
+                cardClasses += " latest";
+            }
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", cardClasses);
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "d-flex justify-content-between align-items-start gap-3 flex-wrap");
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "d-flex flex-column");
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", "branch-title fw-semibold");
+            builder.AddContent(seq++, branch.Name);
+            builder.CloseElement();
+
+            if (branch.PathSegments.Count > 0)
+            {
+                builder.OpenElement(seq++, "span");
+                builder.AddAttribute(seq++, "class", "small text-muted");
+                builder.AddContent(seq++, string.Join('/', branch.PathSegments));
+                builder.CloseElement();
+            }
+
+            if (isLatest && depth > 0)
+            {
+                builder.OpenElement(seq++, "span");
+                builder.AddAttribute(seq++, "class", "badge bg-warning text-dark align-self-start mt-2");
+                builder.AddContent(seq++, "ล่าสุด");
+                builder.CloseElement();
+            }
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "d-flex flex-column text-end gap-1");
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", "badge rounded-pill bg-light text-dark border branch-badge align-self-end");
+            builder.AddContent(seq++, string.IsNullOrEmpty(branch.ErrorMessage) ? branch.Status : "Error");
+            builder.CloseElement();
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", "small text-muted");
+            builder.AddContent(seq++, FormatDate(branch.LastModifiedUtc));
+            builder.CloseElement();
+            builder.CloseElement();
+
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "branch-metrics d-flex flex-wrap gap-2 mb-3");
+
+            builder.OpenElement(seq++, "div");
+            builder.AddContent(seq++, $"ไฟล์ในกิ่ง: {branch.PdfCount}");
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "div");
+            builder.AddContent(seq++, $"ไฟล์รวม: {branch.TotalPdfCount}");
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "div");
+            builder.AddContent(seq++, $"กิ่งย่อย: {branch.Children.Count}");
+            builder.CloseElement();
+
+            builder.CloseElement();
+
+            if (!string.IsNullOrEmpty(branch.ErrorMessage))
+            {
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "alert alert-danger mb-0");
+                builder.AddContent(seq++, branch.ErrorMessage);
+                builder.CloseElement();
+            }
+            else if (orderedDocuments.Count > 0)
+            {
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "document-timelines d-flex flex-column gap-3 mt-3");
+
+                foreach (var document in orderedDocuments)
+                {
+                    builder.AddContent(seq++, RenderDocumentTimeline(document));
+                }
+
+                builder.CloseElement();
+            }
+            else if (recentFiles.Count > 0)
+            {
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "branch-recent small text-muted");
+                builder.AddContent(seq++, "อัปเดตล่าสุด: ");
+
+                for (var i = 0; i < recentFiles.Count; i++)
+                {
+                    var file = recentFiles[i];
+                    builder.OpenElement(seq++, "span");
+                    builder.AddAttribute(seq++, "class", "text-body-secondary");
+                    builder.AddContent(seq++, $"{file.FileName} ({FormatDate(file.LastModifiedUtc)})");
+                    builder.CloseElement();
+                }
+
+                builder.CloseElement();
+            }
+            else
+            {
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "text-muted small");
+                builder.AddContent(seq++, "ยังไม่มีไฟล์ PDF ในกิ่งนี้");
+                builder.CloseElement();
+            }
+
+            builder.CloseElement();
+
+            if (orderedChildren.Any())
+            {
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "branch-children");
+
+                for (var i = 0; i < orderedChildren.Count; i++)
+                {
+                    var child = orderedChildren[i];
+                    builder.AddContent(seq++, RenderBranchNode(child, depth + 1, isLatest: i == 0));
+                }
+
+                builder.CloseElement();
+            }
+
+            builder.CloseElement();
+        };
+    }
+
+    private RenderFragment RenderDocumentTimeline(DocumentTimelineResponse document)
+    {
+        return builder =>
+        {
+            var seq = 0;
+            var versions = document.Versions
+                .OrderByDescending(v => v.UploadedUtc)
+                .ThenByDescending(v => v.Division)
+                .ToList();
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "document-timeline");
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "document-timeline-header d-flex justify-content-between align-items-start gap-2 flex-wrap mb-2");
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "d-flex flex-column");
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", "document-name fw-semibold");
+            builder.AddContent(seq++, document.BaseName);
+            builder.CloseElement();
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "div");
+            builder.AddAttribute(seq++, "class", "d-flex flex-column align-items-end gap-1");
+
+            if (document.LatestUploadedUtc is DateTime latest)
+            {
+                builder.OpenElement(seq++, "span");
+                builder.AddAttribute(seq++, "class", "small text-muted");
+                builder.AddContent(seq++, $"ล่าสุด: {FormatDate(latest)}");
+                builder.CloseElement();
+            }
+
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", "badge bg-success text-white");
+            builder.AddContent(seq++, $"ทั้งหมด {versions.Count} เวอร์ชัน");
+            builder.CloseElement();
+
+            builder.CloseElement();
+
+            builder.CloseElement();
+
+            if (versions.Count > 0)
+            {
+                builder.OpenElement(seq++, "div");
+                builder.AddAttribute(seq++, "class", "version-timeline");
+
+                for (var i = 0; i < versions.Count; i++)
+                {
+                    var version = versions[i];
+                    var versionClasses = "version-node";
+                    if (i == 0)
+                    {
+                        versionClasses += " latest";
+                    }
+
+                    builder.OpenElement(seq++, "div");
+                    builder.AddAttribute(seq++, "class", versionClasses);
+
+                    builder.OpenElement(seq++, "div");
+                    builder.AddAttribute(seq++, "class", "version-content");
+
+                    builder.OpenElement(seq++, "div");
+                    builder.AddAttribute(seq++, "class", "d-flex justify-content-between align-items-start flex-wrap gap-2");
+
+                    builder.OpenElement(seq++, "span");
+                    builder.AddAttribute(seq++, "class", "fw-semibold");
+                    builder.AddContent(seq++, $"Division {version.Division:D2}");
+                    builder.CloseElement();
+
+                    builder.OpenElement(seq++, "span");
+                    builder.AddAttribute(seq++, "class", "small text-muted");
+                    builder.AddContent(seq++, FormatDate(version.UploadedUtc));
+                    builder.CloseElement();
+
+                    builder.CloseElement();
+
+                    builder.OpenElement(seq++, "div");
+                    builder.AddAttribute(seq++, "class", "small text-muted");
+                    builder.AddContent(seq++, version.FileName);
+                    builder.CloseElement();
+
+                    if (!string.IsNullOrWhiteSpace(version.Comment))
+                    {
+                        builder.OpenElement(seq++, "div");
+                        builder.AddAttribute(seq++, "class", "version-comment");
+                        builder.AddContent(seq++, version.Comment);
+                        builder.CloseElement();
+                    }
+
+                    builder.CloseElement();
+                    builder.CloseElement();
+                }
+
+                builder.CloseElement();
+            }
+
+            builder.CloseElement();
+        };
+    }
+
+    private static List<BranchEditStatusResponse> OrderBranches(IEnumerable<BranchEditStatusResponse> branches)
+        => branches
+            .OrderByDescending(b => b.LastModifiedUtc ?? DateTime.MinValue)
+            .ThenBy(b => b.Name, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+    private static string FormatDate(DateTime? value)
+        => value.HasValue ? value.Value.ToLocalTime().ToString("g") : "-";
+
+    private static string FormatDate(DateTime value)
+        => value.ToLocalTime().ToString("g");
+
+
+    private enum SearchTab
+    {
+        Folder,
+        Document
+    }
+
+    private sealed class LineEditStatusResponse
+    {
+        public string Line { get; set; } = string.Empty;
+        public BranchEditStatusResponse? Root { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+
+    private sealed class BranchEditStatusResponse
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<string> PathSegments { get; set; } = new();
+        public int PdfCount { get; set; }
+        public int TotalPdfCount { get; set; }
+        public DateTime? LastModifiedUtc { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public List<FileEditStatusResponse> RecentFiles { get; set; } = new();
+        public List<DocumentTimelineResponse> Documents { get; set; } = new();
+        public List<BranchEditStatusResponse> Children { get; set; } = new();
+        public string? ErrorMessage { get; set; }
+    }
+
+    private sealed class FileEditStatusResponse
+    {
+        public string FileName { get; set; } = string.Empty;
+        public DateTime LastModifiedUtc { get; set; }
+        public long SizeBytes { get; set; }
+        public string RelativePath { get; set; } = string.Empty;
+    }
+
+    private sealed class DocumentTimelineResponse
+    {
+        public string BaseName { get; set; } = string.Empty;
+        public DateTime? LatestUploadedUtc { get; set; }
+        public List<VersionTimelineResponse> Versions { get; set; } = new();
+    }
+
+    private sealed class VersionTimelineResponse
+    {
+        public string FileName { get; set; } = string.Empty;
+        public int Division { get; set; }
+        public DateTime UploadedUtc { get; set; }
+        public string Comment { get; set; } = string.Empty;
+        public string RelativePath { get; set; } = string.Empty;
+    }
+
+    private sealed class FolderSearchResult
+    {
+        public string Line { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string DisplayPath { get; set; } = string.Empty;
+        public int PdfCount { get; set; }
+        public int TotalPdfCount { get; set; }
+        public DateTime? LastModifiedUtc { get; set; }
+    }
+
+    private sealed class DocumentSearchResult
+    {
+        public string Line { get; set; } = string.Empty;
+        public string BaseName { get; set; } = string.Empty;
+        public string DisplayPath { get; set; } = string.Empty;
+        public int VersionCount { get; set; }
+        public DateTime? LatestUploadedUtc { get; set; }
+        public int? LatestDivision { get; set; }
+        public string LatestComment { get; set; } = string.Empty;
+    }
+}

--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -1,7 +1,0 @@
-﻿@page "/"
-
-<PageTitle>Home</PageTitle>
-
-<h1>Hello, world!</h1>
-
-Welcome to your new app.

--- a/Components/Pages/Index.razor
+++ b/Components/Pages/Index.razor
@@ -1,0 +1,854 @@
+@page "/"
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Text.Json
+@using System.Linq
+@inject HttpClient Http
+@inject NavigationManager NavManager
+
+<PageTitle>PDF Browser</PageTitle>
+
+<h1 class="mb-4">📁 PDF Browser</h1>
+
+@if (!string.IsNullOrEmpty(linesError))
+{
+    <div class="alert alert-danger" role="alert">@linesError</div>
+}
+else if (isLoadingLines)
+{
+    <div class="text-muted">กำลังโหลดรายการโฟลเดอร์...</div>
+}
+else
+{
+    <div class="mb-4 d-flex flex-wrap gap-2">
+        @foreach (var line in AllLines)
+        {
+            var isAvailable = availableLines.Contains(line);
+            <button class="btn @(string.Equals(line, selectedLine, StringComparison.OrdinalIgnoreCase) ? "btn-primary" : "btn-outline-primary")"
+                    disabled="@(!isAvailable || (isLoadingFiles && !string.Equals(line, selectedLine, StringComparison.OrdinalIgnoreCase)))"
+                    @onclick="async () => await SelectLine(line)">
+                @line
+                @if (!isAvailable)
+                {
+                    <span class="ms-2 badge bg-secondary">ไม่พบ</span>
+                }
+            </button>
+        }
+    </div>
+
+    @if (!availableLines.Any())
+    {
+        <div class="alert alert-warning" role="alert">
+            ไม่พบโฟลเดอร์ F1, F2 หรือ F3 บนเซิร์ฟเวอร์
+        </div>
+    }
+}
+
+@if (!string.IsNullOrEmpty(filesError))
+{
+    <div class="alert alert-danger" role="alert">@filesError</div>
+}
+else if (isLoadingFiles)
+{
+    <div class="text-muted">กำลังโหลดไฟล์ PDF...</div>
+}
+else if (selectedLine is not null)
+{
+    @if (currentDocuments is null)
+    {
+        <div class="text-muted">เลือกโฟลเดอร์เพื่อดูไฟล์ PDF</div>
+    }
+    else
+    {
+        <nav class="mb-3" aria-label="breadcrumb">
+            <ol class="breadcrumb mb-0">
+                <li class="breadcrumb-item @(currentPathSegments.Count == 0 ? "active" : null)"
+                    aria-current="@(currentPathSegments.Count == 0 ? "page" : null)">
+                    @if (currentPathSegments.Count == 0)
+                    {
+                        @selectedLine
+                    }
+                    else
+                    {
+                        <button class="btn btn-link p-0"
+                                type="button"
+                                @onclick="async () => await NavigateToRootAsync()">@selectedLine</button>
+                    }
+                </li>
+                @for (var i = 0; i < currentPathSegments.Count; i++)
+                {
+                    var folderName = currentPathSegments[i];
+                    var isLast = i == currentPathSegments.Count - 1;
+                    <li class="breadcrumb-item @(isLast ? "active" : null)"
+                        aria-current="@(isLast ? "page" : null)">
+                        @if (isLast)
+                        {
+                            @folderName
+                        }
+                        else
+                        {
+                            <button class="btn btn-link p-0"
+                                    type="button"
+                                    @onclick="async () => await NavigateToBreadcrumbAsync(i)">@folderName</button>
+                        }
+                    </li>
+                }
+            </ol>
+        </nav>
+
+        <div class="card mb-4">
+            <div class="card-header">สร้างโฟลเดอร์สำหรับโมเดลใน @GetCurrentPathDisplay()</div>
+            <div class="card-body d-flex flex-column flex-md-row gap-2 align-items-start align-items-md-center">
+                <input class="form-control"
+                       placeholder="ชื่อโฟลเดอร์ (เช่น Model A)"
+                       @bind="newFolderName"
+                       @bind:event="oninput"
+                       disabled="@isCreatingFolder" />
+                <button class="btn btn-outline-primary"
+                        disabled="@(!CanCreateFolder)"
+                        @onclick="CreateFolderAsync">เพิ่มโฟลเดอร์</button>
+            </div>
+            @if (!string.IsNullOrEmpty(createFolderError))
+            {
+                <div class="card-footer text-danger">@createFolderError</div>
+            }
+            else if (!string.IsNullOrEmpty(createFolderSuccess))
+            {
+                <div class="card-footer text-success">@createFolderSuccess</div>
+            }
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">เพิ่มไฟล์ PDF ลงใน @GetCurrentPathDisplay()</div>
+            <div class="card-body">
+                <div class="row g-2 align-items-center">
+                    <div class="col-12 col-md-auto">
+                        <InputFile OnChange="HandleFileSelected" accept=".pdf" disabled="@isUploadingFile" />
+                    </div>
+                    <div class="col">
+                        @if (!string.IsNullOrEmpty(pendingFileName))
+                        {
+                            <div class="text-muted small">ไฟล์ที่เลือก: @pendingFileName</div>
+                        }
+                        else
+                        {
+                            <div class="text-muted small">เลือกไฟล์ PDF เพื่ออัปโหลด</div>
+                        }
+                    </div>
+                    <div class="col-12 col-md-auto d-flex">
+                        <button class="btn btn-success w-100"
+                                disabled="@(!CanUpload)"
+                                @onclick="UploadSelectedFile">เพิ่มไฟล์</button>
+                    </div>
+                </div>
+                <div class="mt-3">
+                    <textarea class="form-control"
+                              rows="2"
+                              placeholder="บันทึกสิ่งที่อัปเดตหรือข้อมูลเพิ่มเติม"
+                              @bind="uploadComment"
+                              @bind:event="oninput"
+                              disabled="@isUploadingFile"></textarea>
+                    <div class="form-text">ต้องกรอกคอมเมนต์ทุกครั้งที่อัปโหลดไฟล์ใหม่</div>
+                </div>
+            </div>
+            @if (!string.IsNullOrEmpty(uploadError))
+            {
+                <div class="card-footer text-danger">@uploadError</div>
+            }
+            else if (!string.IsNullOrEmpty(uploadSuccess))
+            {
+                <div class="card-footer text-success">@uploadSuccess</div>
+            }
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">โฟลเดอร์ภายใน @GetCurrentPathDisplay()</div>
+            <div class="list-group list-group-flush">
+                @if (currentFolders.Count == 0)
+                {
+                    <div class="list-group-item text-muted">ไม่มีโฟลเดอร์ย่อย</div>
+                }
+                else
+                {
+                    @foreach (var folder in currentFolders)
+                    {
+                        <div class="list-group-item d-flex justify-content-between align-items-center flex-wrap gap-2">
+                            <div class="text-break fw-semibold">@folder</div>
+                            <button class="btn btn-sm btn-outline-primary"
+                                    type="button"
+                                    disabled="@isLoadingFiles"
+                                    @onclick="async () => await EnterFolderAsync(folder)">เปิด</button>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+
+        @if (currentDocuments.Count == 0)
+        {
+            <div class="alert alert-info" role="alert">โฟลเดอร์นี้ไม่มีไฟล์ PDF</div>
+        }
+        else
+        {
+            <div class="list-group mb-4">
+                @foreach (var document in currentDocuments)
+                {
+                    var selectedVersion = GetSelectedVersion(document);
+                    <div class="list-group-item">
+                        <div class="d-flex flex-column flex-lg-row justify-content-between gap-3">
+                            <div class="flex-grow-1">
+                                <div class="fw-semibold">@document.BaseName</div>
+                                @if (selectedVersion is not null)
+                                {
+                                    <div class="small text-muted">
+                                        Division @selectedVersion.Division.ToString("D2") • @selectedVersion.UploadedUtc.ToLocalTime().ToString("g")
+                                    </div>
+                                    @if (!string.IsNullOrWhiteSpace(selectedVersion.Comment))
+                                    {
+                                        <div class="small text-muted">หมายเหตุ: @selectedVersion.Comment</div>
+                                    }
+                                }
+                                else
+                                {
+                                    <div class="small text-muted">ยังไม่มีเวอร์ชันที่อัปโหลด</div>
+                                }
+                            </div>
+                            <div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center gap-2">
+                                <select class="form-select form-select-sm"
+                                        disabled="@(document.Versions.Count == 0)"
+                                        value="@(selectedVersion?.FileName)"
+                                        @onchange="e => ChangeSelectedVersion(document, e.Value?.ToString())">
+                                    @foreach (var version in document.Versions)
+                                    {
+                                        <option value="@version.FileName">@FormatVersionLabel(version)</option>
+                                    }
+                                </select>
+                                <a class="btn btn-sm btn-outline-secondary @(selectedVersion is null ? "disabled" : string.Empty)"
+                                   href="@(selectedVersion is not null ? BuildPdfUrl(selectedLine!, selectedVersion.FileName) : "#")"
+                                   target="_blank"
+                                   rel="noopener noreferrer"
+                                   tabindex="@(selectedVersion is null ? -1 : 0)">
+                                    เปิด
+                                </a>
+                                <button class="btn btn-sm btn-primary"
+                                        type="button"
+                                        disabled="@(selectedVersion is null)"
+                                        @onclick="() => PreviewDocument(document)">
+                                    พรีวิว
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    }
+}
+
+@if (previewVersion is not null && previewBaseName is not null && selectedLine is not null)
+{
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div class="d-flex align-items-center gap-2">
+                <strong>Preview:</strong>
+                <span>@previewBaseName</span>
+                <span class="badge bg-primary">Division @previewVersion.Division.ToString("D2")</span>
+            </div>
+            <div class="d-flex gap-2">
+                <a class="btn btn-sm btn-outline-secondary"
+                   href="@BuildPdfUrl(selectedLine!, previewVersion.FileName)"
+                   target="_blank" rel="noopener noreferrer">เปิดในแท็บใหม่</a>
+                <button class="btn btn-sm btn-outline-danger" @onclick="ClosePreview">ปิดพรีวิว</button>
+            </div>
+        </div>
+        <div class="card-body p-0">
+            <div class="px-3 py-2 border-bottom bg-light">
+                <div class="small text-muted">อัปโหลด: @previewVersion.UploadedUtc.ToLocalTime().ToString("g")</div>
+                @if (!string.IsNullOrWhiteSpace(previewVersion.Comment))
+                {
+                    <div class="small">หมายเหตุ: @previewVersion.Comment</div>
+                }
+            </div>
+            <iframe src="@BuildPdfUrl(selectedLine!, previewVersion.FileName)"
+                    style="width:100%; height:70vh; border:0;"
+                    title="PDF Preview"></iframe>
+        </div>
+    </div>
+}
+
+@code {
+    private static readonly string[] AllLines = ["F1", "F2", "F3"];
+    private const long MaxUploadBytes = 50L * 1024 * 1024;
+
+    private readonly HashSet<string> availableLines = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, VersionResponse> selectedDocumentVersions = new(StringComparer.OrdinalIgnoreCase);
+    private List<DocumentResponse>? currentDocuments;
+    private List<string> currentFolders = new();
+    private List<string> currentPathSegments = new();
+    private string? selectedLine;
+    private string? previewBaseName;
+    private VersionResponse? previewVersion;
+    private bool isLoadingLines;
+    private bool isLoadingFiles;
+    private bool isUploadingFile;
+    private bool isCreatingFolder;
+    private string? linesError;
+    private string? filesError;
+    private string? uploadError;
+    private string? uploadSuccess;
+    private string? createFolderError;
+    private string? createFolderSuccess;
+    private IBrowserFile? pendingUpload;
+    private string? pendingFileName;
+    private string? newFolderName = string.Empty;
+    private string uploadComment = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadFoldersAsync();
+    }
+
+    private async Task LoadFoldersAsync()
+    {
+        try
+        {
+            isLoadingLines = true;
+            linesError = null;
+            var foldersEndpoint = NavManager.ToAbsoluteUri("/api/folders");
+            var folders = await Http.GetFromJsonAsync<List<string>>(foldersEndpoint);
+            availableLines.Clear();
+            if (folders is not null)
+            {
+                foreach (var folder in folders)
+                {
+                    availableLines.Add(folder);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            linesError = $"ไม่สามารถโหลดโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isLoadingLines = false;
+        }
+
+        if (availableLines.Count > 0 && selectedLine is null)
+        {
+            var preferred = AllLines.FirstOrDefault(line => availableLines.Contains(line));
+            if (preferred is not null)
+            {
+                await SelectLine(preferred);
+            }
+        }
+    }
+
+    private async Task SelectLine(string line)
+    {
+        if (!availableLines.Contains(line))
+        {
+            return;
+        }
+
+        selectedLine = line;
+        previewBaseName = null;
+        previewVersion = null;
+        currentDocuments = null;
+        currentFolders = new List<string>();
+        currentPathSegments = new List<string>();
+        selectedDocumentVersions.Clear();
+        ResetUploadState();
+        ResetFolderCreationState();
+        filesError = null;
+        await LoadFilesAsync(line, Array.Empty<string>());
+    }
+
+    private async Task LoadFilesAsync(string line, IReadOnlyList<string>? pathSegments = null)
+    {
+        var targetSegments = pathSegments is null
+            ? new List<string>(currentPathSegments)
+            : new List<string>(pathSegments);
+
+        currentDocuments = null;
+        try
+        {
+            isLoadingFiles = true;
+            filesError = null;
+            var query = BuildPathQuery(targetSegments);
+            var filesEndpoint = NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(line)}{query}");
+            var listing = await Http.GetFromJsonAsync<FolderListingResponse>(filesEndpoint);
+
+            if (listing is null)
+            {
+                currentFolders = new List<string>();
+                currentDocuments = new List<DocumentResponse>();
+                currentPathSegments = targetSegments;
+                selectedDocumentVersions.Clear();
+                return;
+            }
+
+            currentFolders = listing.Folders is { } folders
+                ? new List<string>(folders)
+                : new List<string>();
+
+            currentDocuments = listing.Documents is { } documents
+                ? new List<DocumentResponse>(documents)
+                : new List<DocumentResponse>();
+
+            currentPathSegments = listing.PathSegments is { } pathList
+                ? new List<string>(pathList)
+                : new List<string>(targetSegments);
+
+            selectedDocumentVersions.Clear();
+
+            foreach (var document in currentDocuments)
+            {
+                document.Versions ??= new List<VersionResponse>();
+                var defaultVersion = document.Versions
+                    .OrderByDescending(v => v.Division)
+                    .ThenByDescending(v => v.UploadedUtc)
+                    .FirstOrDefault();
+
+                if (defaultVersion is not null)
+                {
+                    selectedDocumentVersions[document.BaseName] = defaultVersion;
+                }
+            }
+
+            SyncPreviewAfterReload();
+        }
+        catch (Exception ex)
+        {
+            filesError = $"ไม่สามารถโหลดไฟล์ได้: {ex.Message}";
+            currentFolders = new List<string>();
+            currentDocuments = new List<DocumentResponse>();
+            currentPathSegments = targetSegments;
+            selectedDocumentVersions.Clear();
+            previewBaseName = null;
+            previewVersion = null;
+        }
+        finally
+        {
+            isLoadingFiles = false;
+        }
+    }
+
+    private VersionResponse? GetSelectedVersion(DocumentResponse document)
+    {
+        if (selectedDocumentVersions.TryGetValue(document.BaseName, out var version))
+        {
+            return version;
+        }
+
+        var fallback = document.Versions
+            .OrderByDescending(v => v.Division)
+            .ThenByDescending(v => v.UploadedUtc)
+            .FirstOrDefault();
+
+        if (fallback is not null)
+        {
+            selectedDocumentVersions[document.BaseName] = fallback;
+        }
+
+        return fallback;
+    }
+
+    private void ChangeSelectedVersion(DocumentResponse document, string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return;
+        }
+
+        var version = document.Versions
+            .FirstOrDefault(v => string.Equals(v.FileName, fileName, StringComparison.OrdinalIgnoreCase));
+
+        if (version is null)
+        {
+            return;
+        }
+
+        selectedDocumentVersions[document.BaseName] = version;
+
+        if (previewBaseName is not null && string.Equals(previewBaseName, document.BaseName, StringComparison.OrdinalIgnoreCase))
+        {
+            previewVersion = version;
+        }
+    }
+
+    private void PreviewDocument(DocumentResponse document)
+    {
+        var version = GetSelectedVersion(document);
+        if (version is null)
+        {
+            return;
+        }
+
+        previewBaseName = document.BaseName;
+        previewVersion = version;
+    }
+
+    private void ClosePreview()
+    {
+        previewBaseName = null;
+        previewVersion = null;
+    }
+
+    private static string FormatVersionLabel(VersionResponse version)
+    {
+        var divisionLabel = $"Division {version.Division:D2}";
+        var timestamp = version.UploadedUtc.ToLocalTime().ToString("g");
+
+        if (string.IsNullOrWhiteSpace(version.Comment))
+        {
+            return $"{divisionLabel} • {timestamp}";
+        }
+
+        var comment = version.Comment.Length > 40
+            ? version.Comment.Substring(0, 40) + "…"
+            : version.Comment;
+
+        return $"{divisionLabel} • {timestamp} • {comment}";
+    }
+
+    private string BuildPdfUrl(string line, string file)
+    {
+        var baseUrl = $"/pdf/{Uri.EscapeDataString(line)}/{Uri.EscapeDataString(file)}";
+        var query = BuildPathQuery(currentPathSegments);
+        return string.IsNullOrEmpty(query) ? baseUrl : $"{baseUrl}{query}";
+    }
+
+    private void SyncPreviewAfterReload()
+    {
+        if (previewBaseName is null || currentDocuments is null)
+        {
+            previewBaseName = null;
+            previewVersion = null;
+            return;
+        }
+
+        var document = currentDocuments.FirstOrDefault(d => string.Equals(d.BaseName, previewBaseName, StringComparison.OrdinalIgnoreCase));
+        if (document is null)
+        {
+            previewBaseName = null;
+            previewVersion = null;
+            return;
+        }
+
+        VersionResponse? updatedVersion = null;
+
+        if (previewVersion is not null)
+        {
+            updatedVersion = document.Versions
+                .FirstOrDefault(v => string.Equals(v.FileName, previewVersion.FileName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        updatedVersion ??= GetSelectedVersion(document);
+
+        if (updatedVersion is null)
+        {
+            previewBaseName = null;
+            previewVersion = null;
+        }
+        else
+        {
+            previewVersion = updatedVersion;
+        }
+    }
+
+    private string GetCurrentPathDisplay()
+    {
+        if (selectedLine is null)
+        {
+            return string.Empty;
+        }
+
+        return currentPathSegments.Count == 0
+            ? selectedLine
+            : $"{selectedLine}\\{string.Join('\\', currentPathSegments)}";
+    }
+
+    private async Task NavigateToRootAsync()
+    {
+        if (selectedLine is null)
+        {
+            return;
+        }
+
+        previewBaseName = null;
+        previewVersion = null;
+        await LoadFilesAsync(selectedLine, Array.Empty<string>());
+    }
+
+    private async Task NavigateToBreadcrumbAsync(int depth)
+    {
+        if (selectedLine is null)
+        {
+            return;
+        }
+
+        if (depth < 0 || depth >= currentPathSegments.Count)
+        {
+            return;
+        }
+
+        previewBaseName = null;
+        previewVersion = null;
+        var target = currentPathSegments.Take(depth + 1).ToList();
+        await LoadFilesAsync(selectedLine, target);
+    }
+
+    private async Task EnterFolderAsync(string folder)
+    {
+        if (selectedLine is null || string.IsNullOrWhiteSpace(folder))
+        {
+            return;
+        }
+
+        previewBaseName = null;
+        previewVersion = null;
+        var target = new List<string>(currentPathSegments) { folder };
+        await LoadFilesAsync(selectedLine, target);
+    }
+
+    private static string BuildPathQuery(IReadOnlyList<string> segments)
+    {
+        if (segments.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var encoded = string.Join('/', segments.Select(Uri.EscapeDataString));
+        return $"?path={encoded}";
+    }
+
+    private void HandleFileSelected(InputFileChangeEventArgs e)
+    {
+        uploadError = null;
+        uploadSuccess = null;
+        pendingUpload = null;
+        pendingFileName = null;
+
+        var file = e.File;
+        if (file is null)
+        {
+            uploadError = "ไม่พบไฟล์ที่เลือก";
+            return;
+        }
+
+        if (!file.Name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+        {
+            uploadError = "กรุณาเลือกไฟล์ PDF (.pdf)";
+            return;
+        }
+
+        pendingUpload = file;
+        pendingFileName = file.Name;
+    }
+
+    private bool CanUpload => selectedLine is not null && pendingUpload is not null && !isUploadingFile && !string.IsNullOrWhiteSpace(uploadComment);
+
+    private async Task UploadSelectedFile()
+    {
+        if (!CanUpload || selectedLine is null || pendingUpload is null)
+        {
+            return;
+        }
+
+        var comment = uploadComment?.Trim();
+        if (string.IsNullOrWhiteSpace(comment))
+        {
+            uploadError = "กรุณากรอกคอมเมนต์สำหรับการอัปโหลด";
+            uploadSuccess = null;
+            return;
+        }
+
+        uploadError = null;
+        uploadSuccess = null;
+        isUploadingFile = true;
+
+        try
+        {
+            var uploadEndpoint = NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(selectedLine)}/upload{BuildPathQuery(currentPathSegments)}");
+            using var content = new MultipartFormDataContent();
+            var stream = pendingUpload.OpenReadStream(MaxUploadBytes);
+            var streamContent = new StreamContent(stream);
+            streamContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/pdf");
+            content.Add(streamContent, "file", pendingUpload.Name);
+            content.Add(new StringContent(comment), "comment");
+
+            var response = await Http.PostAsync(uploadEndpoint, content);
+            if (response.IsSuccessStatusCode)
+            {
+                var uploadInfo = await response.Content.ReadFromJsonAsync<UploadResponse>();
+                if (uploadInfo is not null && !string.IsNullOrWhiteSpace(uploadInfo.BaseName))
+                {
+                    uploadSuccess = $"อัปโหลด Division {uploadInfo.Division:D2} สำหรับ {uploadInfo.BaseName} เรียบร้อย";
+                }
+                else
+                {
+                    var uploadedName = pendingFileName ?? pendingUpload.Name;
+                    uploadSuccess = string.IsNullOrEmpty(uploadedName)
+                        ? "อัปโหลดไฟล์เรียบร้อย"
+                        : $"อัปโหลดไฟล์ {uploadedName} เรียบร้อย";
+                }
+                await LoadFilesAsync(selectedLine, currentPathSegments);
+                pendingUpload = null;
+                pendingFileName = null;
+                uploadComment = string.Empty;
+            }
+            else
+            {
+                uploadError = await ExtractErrorMessageAsync(response);
+            }
+        }
+        catch (Exception ex)
+        {
+            uploadError = $"อัปโหลดไม่สำเร็จ: {ex.Message}";
+        }
+        finally
+        {
+            isUploadingFile = false;
+        }
+    }
+
+    private void ResetUploadState()
+    {
+        isUploadingFile = false;
+        uploadError = null;
+        uploadSuccess = null;
+        pendingUpload = null;
+        pendingFileName = null;
+        uploadComment = string.Empty;
+    }
+
+    private bool CanCreateFolder => selectedLine is not null && !string.IsNullOrWhiteSpace(newFolderName) && !isCreatingFolder;
+
+    private async Task CreateFolderAsync()
+    {
+        if (selectedLine is null)
+        {
+            return;
+        }
+
+        var desiredName = newFolderName?.Trim();
+        if (string.IsNullOrWhiteSpace(desiredName))
+        {
+            createFolderError = "กรุณากรอกชื่อโฟลเดอร์";
+            createFolderSuccess = null;
+            return;
+        }
+
+        isCreatingFolder = true;
+        createFolderError = null;
+        createFolderSuccess = null;
+
+        try
+        {
+            var endpoint = NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(selectedLine)}/subfolders{BuildPathQuery(currentPathSegments)}");
+            var response = await Http.PostAsJsonAsync(endpoint, new { name = desiredName });
+
+            if (response.IsSuccessStatusCode)
+            {
+                createFolderSuccess = $"สร้างโฟลเดอร์ {desiredName} เรียบร้อย";
+                newFolderName = string.Empty;
+                await LoadFilesAsync(selectedLine, currentPathSegments);
+            }
+            else
+            {
+                createFolderError = await ExtractErrorMessageAsync(response);
+            }
+        }
+        catch (Exception ex)
+        {
+            createFolderError = $"ไม่สามารถสร้างโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isCreatingFolder = false;
+        }
+    }
+
+    private void ResetFolderCreationState()
+    {
+        isCreatingFolder = false;
+        createFolderError = null;
+        createFolderSuccess = null;
+        newFolderName = string.Empty;
+    }
+
+    private sealed class FolderListingResponse
+    {
+        public List<string> PathSegments { get; set; } = new();
+        public List<string> Folders { get; set; } = new();
+        public List<string> Files { get; set; } = new();
+        public List<DocumentResponse> Documents { get; set; } = new();
+    }
+
+    private sealed class DocumentResponse
+    {
+        public string BaseName { get; set; } = string.Empty;
+        public List<VersionResponse> Versions { get; set; } = new();
+    }
+
+    private sealed class VersionResponse
+    {
+        public string FileName { get; set; } = string.Empty;
+        public int Division { get; set; }
+        public DateTime UploadedUtc { get; set; }
+        public string Comment { get; set; } = string.Empty;
+    }
+
+    private sealed class UploadResponse
+    {
+        public string File { get; set; } = string.Empty;
+        public string BaseName { get; set; } = string.Empty;
+        public int Division { get; set; }
+        public string Comment { get; set; } = string.Empty;
+        public DateTime UploadedUtc { get; set; }
+    }
+
+    private static async Task<string> ExtractErrorMessageAsync(HttpResponseMessage response)
+    {
+        var message = await response.Content.ReadAsStringAsync();
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+
+        if (string.Equals(mediaType, "application/problem+json", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(message);
+                if (doc.RootElement.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
+                {
+                    var detailValue = detail.GetString();
+                    if (!string.IsNullOrWhiteSpace(detailValue))
+                    {
+                        return detailValue!;
+                    }
+                }
+
+                if (doc.RootElement.TryGetProperty("title", out var title) && title.ValueKind == JsonValueKind.String)
+                {
+                    var titleValue = title.GetString();
+                    if (!string.IsNullOrWhiteSpace(titleValue))
+                    {
+                        return titleValue!;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // ignore parsing failures and fall back to the raw message
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            message = $"คำขอไม่สำเร็จ (รหัส {response.StatusCode})";
+        }
+
+        return message;
+    }
+}

--- a/Components/Pages/PdfBrowser.razor
+++ b/Components/Pages/PdfBrowser.razor
@@ -1,16 +1,38 @@
 @page "/pdfs"
 @using System
+@using System.Collections.Generic
+@using System.Linq
 @using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
 @inject HttpClient Http
-@inject NavigationManager Navigation
+@inject NavigationManager NavManager
 
 <h2 class="mb-3">📄 PDF Browser (Local Server)</h2>
 
+<div class="mb-3">
+    <label class="form-label fw-semibold">เลือกโฟลเดอร์</label>
+    <select class="form-select" value="@selectedLine" @onchange="HandleFolderChanged" disabled="@isLoadingFolders">
+        <option value="" disabled>-- เลือกโฟลเดอร์ --</option>
+        @foreach (var line in availableLines)
+        {
+            <option value="@line">@line</option>
+        }
+    </select>
+    @if (!string.IsNullOrEmpty(foldersError))
+    {
+        <div class="alert alert-danger mt-2" role="alert">@foldersError</div>
+    }
+</div>
+
 <div class="row">
-    <div class="col-4">
-        <input class="form-control mb-2" placeholder="ค้นหาไฟล์..." @bind="search" @bind:event="oninput" />
+    <div class="col-12 col-lg-4 mb-3 mb-lg-0">
+        <input class="form-control mb-2"
+               placeholder="ค้นหาไฟล์..."
+               @bind="search"
+               @bind:event="oninput"
+               disabled="@isLoadingFiles" />
         <ul class="list-group" style="max-height: 70vh; overflow:auto;">
-            @if (files is null)
+            @if (isLoadingFiles)
             {
                 <li class="list-group-item">กำลังโหลด...</li>
             }
@@ -22,29 +44,40 @@
             {
                 @foreach (var f in Filtered)
                 {
-                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <button class="btn btn-link p-0" @onclick="() => Select(f.name)">@f.name</button>
-                        <a class="btn btn-sm btn-outline-secondary"
-                           href="@($"/api/pdfs/{Uri.EscapeDataString(f.name)}/download")" target="_blank">ดาวน์โหลด</a>
+                    <li class="list-group-item d-flex justify-content-between align-items-center @(string.Equals(selected, f, StringComparison.Ordinal) ? "active" : string.Empty)">
+                        <span class="flex-grow-1 text-truncate me-3" title="@f">@f</span>
+                        <div class="btn-group" role="group">
+                            <button class="btn btn-sm btn-outline-primary" @onclick="() => Select(f)" disabled="@string.IsNullOrEmpty(selectedLine)">แสดง</button>
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="@(selectedLine is null ? null : BuildPdfUrl(selectedLine, f))"
+                               target="_blank" rel="noopener noreferrer"
+                               aria-disabled="@(selectedLine is null)">เปิด</a>
+                        </div>
                     </li>
                 }
             }
         </ul>
     </div>
 
-    <div class="col-8">
-        @if (!string.IsNullOrEmpty(selected))
+    <div class="col-12 col-lg-8">
+        @if (!string.IsNullOrEmpty(filesError))
+        {
+            <div class="alert alert-danger" role="alert">@filesError</div>
+        }
+        else if (!string.IsNullOrEmpty(selected) && !string.IsNullOrEmpty(selectedLine))
         {
             <div class="d-flex justify-content-between align-items-center mb-2">
                 <h5 class="m-0">พรีวิว: @selected</h5>
                 <a class="btn btn-sm btn-primary"
-                   href="@($"/api/pdfs/{Uri.EscapeDataString(selected)}")" target="_blank">เปิดในแท็บใหม่</a>
+                   href="@BuildPdfUrl(selectedLine!, selected)"
+                   target="_blank" rel="noopener noreferrer">เปิดในแท็บใหม่</a>
             </div>
 
             <iframe style="width:100%; height:75vh; border:1px solid #ccc; border-radius:8px;"
-                    src="@($"/api/pdfs/{Uri.EscapeDataString(selected)}")"></iframe>
+                    src="@BuildPdfUrl(selectedLine!, selected)"
+                    title="PDF Preview"></iframe>
         }
-        else
+        else if (!isLoadingFiles)
         {
             <div class="text-muted">เลือกไฟล์ทางซ้ายเพื่อดูพรีวิว</div>
         }
@@ -52,48 +85,121 @@
 </div>
 
 @code {
-    record PdfInfo(string name, long sizeBytes, DateTime modifiedUtc);
-    List<PdfInfo>? files;
+    readonly List<string> availableLines = new();
+    List<string>? files;
+    string? selectedLine;
     string? selected;
+    string? foldersError;
+    string? filesError;
+    bool isLoadingFolders;
+    bool isLoadingFiles;
 
-    string? previewSrc;
-    Guid previewNonce = Guid.Empty;
-    string search = "";
+    string search = string.Empty;
 
-    IEnumerable<PdfInfo> Filtered => (files ?? Enumerable.Empty<PdfInfo>())
-        .Where(f => string.IsNullOrWhiteSpace(search) || f.name.Contains(search, StringComparison.OrdinalIgnoreCase));
+    IEnumerable<string> Filtered => (files ?? Enumerable.Empty<string>())
+        .Where(f => string.IsNullOrWhiteSpace(search) || f.Contains(search, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = Navigation.ToAbsoluteUri("/api/pdfs");
-        files = await Http.GetFromJsonAsync<List<PdfInfo>>(endpoint);
-        selected = files?.FirstOrDefault()?.name;
+        await LoadFoldersAsync();
     }
 
-    void Select(string name) => selected = name;
+    async Task LoadFoldersAsync()
+    {
+        try
+        {
+            isLoadingFolders = true;
+            foldersError = null;
+            var folders = await Http.GetFromJsonAsync<List<string>>(NavManager.ToAbsoluteUri("/api/folders"));
+            availableLines.Clear();
+            if (folders is not null)
+            {
+                foreach (var folder in folders)
+                {
+                    availableLines.Add(folder);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            foldersError = $"ไม่สามารถโหลดโฟลเดอร์ได้: {ex.Message}";
+        }
+        finally
+        {
+            isLoadingFolders = false;
+        }
+
+        if (availableLines.Count > 0)
+        {
+            var nextLine = GetMatchingLine(selectedLine) ?? availableLines.First();
+            await LoadFilesAsync(nextLine);
+        }
+        else
+        {
+            selectedLine = null;
+            files = new List<string>();
+            selected = null;
+        }
+    }
+
+    async Task LoadFilesAsync(string line)
+    {
+        selectedLine = line;
+        selected = null;
+        filesError = null;
+        try
+        {
+            isLoadingFiles = true;
+            files = await Http.GetFromJsonAsync<List<string>>(NavManager.ToAbsoluteUri($"/api/folders/{Uri.EscapeDataString(line)}"));
+            files ??= new List<string>();
+        }
+        catch (Exception ex)
+        {
+            filesError = $"ไม่สามารถโหลดไฟล์ได้: {ex.Message}";
+            files = new List<string>();
+        }
+        finally
+        {
+            isLoadingFiles = false;
+        }
+
+        var first = files.FirstOrDefault();
+        if (first is not null)
+        {
+            ApplySelection(first, force: true);
+        }
+    }
 
     void Select(string name) => ApplySelection(name);
 
-    string PreviewUrl(string name) => $"/api/pdfs/{Uri.EscapeDataString(name)}";
-
-    string BuildPreviewSource(string name, Guid nonce)
+    async Task HandleFolderChanged(ChangeEventArgs args)
     {
-        var baseUri = Navigation.ToAbsoluteUri(PreviewUrl(name)).ToString();
-        var separator = baseUri.Contains('?') ? '&' : '?';
-        return $"{baseUri}{separator}v={nonce}";
-    }
-
-    string DownloadUrl(string name) => $"{PreviewUrl(name)}/download";
-
-    string GetItemClasses(string name)
-    {
-        var classes = "list-group-item";
-        if (string.Equals(selected, name, StringComparison.Ordinal))
+        var line = args.Value?.ToString();
+        var match = GetMatchingLine(line);
+        if (!string.IsNullOrWhiteSpace(match))
         {
-            classes += " active";
+            await LoadFilesAsync(match);
+            return;
         }
 
-        return classes;
+        selectedLine = null;
+        files = new List<string>();
+        selected = null;
+    }
+
+    static string BuildPdfUrl(string line, string name)
+    {
+        return $"/pdf/{Uri.EscapeDataString(line)}/{Uri.EscapeDataString(name)}";
+    }
+
+    string? GetMatchingLine(string? line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return null;
+        }
+
+        return availableLines.FirstOrDefault(l => string.Equals(l, line, StringComparison.OrdinalIgnoreCase));
     }
 
     bool ApplySelection(string name, bool force = false)
@@ -104,8 +210,6 @@
         }
 
         selected = name;
-        previewNonce = Guid.NewGuid();
-        previewSrc = BuildPreviewSource(name, previewNonce);
         return true;
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,21 @@
+using System.Net.Mime;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+
+const long MaxUploadBytes = 50L * 1024 * 1024; // 50 MB upload limit per PDF
+
 var builder = WebApplication.CreateBuilder(args);
 
-// เปิดโหมด Blazor Server
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddHttpClient();
+builder.Services.Configure<FormOptions>(options =>
+{
+    options.MultipartBodyLengthLimit = MaxUploadBytes;
+});
 
 var app = builder.Build();
 
@@ -18,85 +29,984 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseAntiforgery();
 
-// ====== PDF APIs ======
-var pdfRoot = app.Configuration["PdfStorage:Root"]
-              ?? Path.Combine(app.Environment.ContentRootPath, "PDFs");
-Directory.CreateDirectory(pdfRoot);
+// ====== PDF browser configuration ======
+// TODO: Replace the UNC path below with the actual PDF root if it differs in your environment.
+//       Ensure the web process identity has READ/WRITE access on both the share and NTFS ACLs.
+var pdfRoot = builder.Configuration["PdfStorage:Root"]
+              ?? @"\\\\10.192.132.91\\PdfRoot";
 
-// กัน path traversal + บังคับ .pdf
-bool IsSafeFileName(string name)
+if (!Directory.Exists(pdfRoot))
 {
-    if (!name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
-    {
-        return false;
-    }
-
-    if (!string.Equals(Path.GetFileName(name), name, StringComparison.Ordinal))
-    {
-        return false;
-    }
-
-    return name.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+    app.Logger.LogWarning("Configured PDF root '{PdfRoot}' is not accessible. Confirm the share path and permissions.", pdfRoot);
 }
 
-// 1) รายการไฟล์
-app.MapGet("/api/pdfs", () =>
-{
-    var files = Directory.EnumerateFiles(pdfRoot, "*.pdf", SearchOption.TopDirectoryOnly)
-                         .Select(full => new
-                         {
-                             name = Path.GetFileName(full),
-                             sizeBytes = new FileInfo(full).Length,
-                             modifiedUtc = File.GetLastWriteTimeUtc(full),
-                         })
-                         .OrderByDescending(f => f.modifiedUtc);
-    return Results.Ok(files);
-});
+var allowedLines = new[] { "F1", "F2", "F3" };
+var pdfService = new PdfBrowserService(pdfRoot, allowedLines, MaxUploadBytes, app.Logger);
 
-IResult? ValidatePdfRequest(string name, out string fullPath)
-{
-    fullPath = string.Empty;
-    if (!IsSafeFileName(name))
-    {
-        return Results.BadRequest("invalid file name");
-    }
+app.MapGet("/api/folders", () => pdfService.GetExistingLines());
+app.MapGet("/api/folders/{line}", (string line, HttpRequest request)
+        => pdfService.GetFolderListing(line, request.Query["path"].ToString()));
+app.MapGet("/pdf/{line}/{file}", (string line, string file, HttpRequest request)
+        => pdfService.GetPdfStream(line, file, request.Query["path"].ToString()));
+app.MapGet("/api/edit-status", () => pdfService.GetEditStatuses());
+app.MapPost("/api/folders/{line}/upload", async (string line, HttpRequest request)
+        => await pdfService.UploadPdfAsync(line, request));
+app.MapPost("/api/folders/{line}/subfolders", async (string line, HttpContext context)
+        => await pdfService.CreateSubfolderAsync(line, context));
+// ====== /PDF browser configuration ======
 
-    var candidate = Path.Combine(pdfRoot, name);
-    if (!System.IO.File.Exists(candidate))
-    {
-        return Results.NotFound();
-    }
-
-    fullPath = candidate;
-    return null;
-}
-
-// 2) พรีวิว inline
-app.MapGet("/api/pdfs/{name}", (string name) =>
-{
-    if (ValidatePdfRequest(name, out var fullPath) is { } error)
-    {
-        return error;
-    }
-
-    return Results.File(fullPath, "application/pdf", enableRangeProcessing: true);
-});
-
-// 3) ดาวน์โหลด (บังคับแนบไฟล์)
-app.MapGet("/api/pdfs/{name}/download", (string name) =>
-{
-    if (ValidatePdfRequest(name, out var fullPath) is { } error)
-    {
-        return error;
-    }
-
-    var stream = System.IO.File.OpenRead(fullPath);
-    return Results.File(stream, "application/pdf", fileDownloadName: name, enableRangeProcessing: true);
-});
-// ====== /PDF APIs ======
-
-// NOTE: เปลี่ยน BlazorPdfApp เป็นชื่อ namespace โปรเจกต์คุณถ้าไม่ตรง
 app.MapRazorComponents<BlazorPdfApp.Components.App>()
    .AddInteractiveServerRenderMode();
 
 app.Run();
+
+internal sealed record FolderListing(
+    string Line,
+    IReadOnlyList<string> PathSegments,
+    IReadOnlyList<string> Folders,
+    IReadOnlyList<string> Files,
+    IReadOnlyList<FolderDocument> Documents);
+internal sealed record FolderDocument(string BaseName, IReadOnlyList<PdfVersion> Versions);
+internal sealed record PdfVersion(string FileName, int Division, DateTime UploadedUtc, string Comment);
+internal sealed record CreateFolderRequest(string? Name);
+internal sealed record LineEditStatus(string Line, BranchEditStatus? Root, string? ErrorMessage);
+internal sealed record BranchEditStatus(
+    string Name,
+    IReadOnlyList<string> PathSegments,
+    int PdfCount,
+    int TotalPdfCount,
+    DateTime? LastModifiedUtc,
+    string Status,
+    IReadOnlyList<FileEditStatus> RecentFiles,
+    IReadOnlyList<DocumentEditStatus> Documents,
+    IReadOnlyList<BranchEditStatus> Children,
+    string? ErrorMessage);
+internal sealed record FileEditStatus(string FileName, DateTime LastModifiedUtc, long SizeBytes, string RelativePath);
+internal sealed record DocumentEditStatus(string BaseName, DateTime? LatestUploadedUtc, IReadOnlyList<PdfVersionStatus> Versions);
+internal sealed record PdfVersionStatus(string FileName, int Division, DateTime UploadedUtc, string Comment, string RelativePath);
+internal sealed class PdfMetadata
+{
+    public Dictionary<string, List<PdfVersionMetadata>> Documents { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}
+
+internal sealed class PdfVersionMetadata
+{
+    public string FileName { get; set; } = string.Empty;
+    public int Division { get; set; }
+    public DateTime UploadedUtc { get; set; }
+    public string Comment { get; set; } = string.Empty;
+}
+
+internal sealed class PdfBrowserService
+{
+    private readonly string _pdfRoot;
+    private readonly HashSet<string> _allowedLines;
+    private readonly long _maxUploadBytes;
+    private readonly ILogger _logger;
+    private const string MetadataFileName = ".pdf-metadata.json";
+    private const int MaxCommentLength = 500;
+    private static readonly JsonSerializerOptions MetadataSerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    internal PdfBrowserService(string pdfRoot, IEnumerable<string> allowedLines, long maxUploadBytes, ILogger logger)
+    {
+        _pdfRoot = pdfRoot;
+        _allowedLines = new HashSet<string>(allowedLines, StringComparer.OrdinalIgnoreCase);
+        _maxUploadBytes = maxUploadBytes;
+        _logger = logger;
+    }
+
+    internal IResult GetExistingLines()
+    {
+        try
+        {
+            var existing = _allowedLines
+                .Select(line => new { line, path = Path.Combine(_pdfRoot, line) })
+                .Where(x => Directory.Exists(x.path))
+                .Select(x => x.line)
+                .OrderBy(line => line, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return Results.Ok(existing);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "Failed to enumerate folders under {PdfRoot}", _pdfRoot);
+            return Results.Problem("ไม่สามารถอ่านรายการโฟลเดอร์ได้ กรุณาตรวจสอบการแชร์และสิทธิ์การเข้าถึง");
+        }
+    }
+
+    internal IResult GetFolderListing(string line, string? rawPath)
+    {
+        var pathSegments = ParsePathSegments(rawPath);
+        if (!TryResolveDirectory(line, pathSegments, out var directoryPath, out var normalizedSegments, out var error))
+        {
+            return error ?? Results.NotFound("Unknown folder");
+        }
+
+        try
+        {
+            var folders = Directory.EnumerateDirectories(directoryPath!, "*", SearchOption.TopDirectoryOnly)
+                .Select(Path.GetFileName)
+                .Where(name => name is not null && IsValidFolderName(name))
+                .Select(name => name!)
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var files = Directory.EnumerateFiles(directoryPath!, "*.pdf", SearchOption.TopDirectoryOnly)
+                .Where(path => IsValidPdfFileName(Path.GetFileName(path)))
+                .Select(Path.GetFileName)
+                .Where(name => name is not null)
+                .Select(name => name!)
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var metadata = LoadMetadata(directoryPath!);
+            var metadataChanged = PruneMetadata(metadata, files);
+            var documents = BuildDocumentListing(directoryPath!, files, metadata);
+
+            if (metadataChanged)
+            {
+                TryPersistMetadata(directoryPath!, metadata);
+            }
+
+            return Results.Ok(new FolderListing(
+                line,
+                normalizedSegments ?? new List<string>(),
+                folders,
+                files,
+                documents));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "Failed to enumerate files for {Line} in {PdfRoot}", line, _pdfRoot);
+            return Results.Problem("ไม่สามารถอ่านไฟล์ในโฟลเดอร์ที่เลือกได้ กรุณาตรวจสอบสิทธิ์การเข้าถึง");
+        }
+    }
+
+    internal IResult GetPdfStream(string line, string file, string? rawPath)
+    {
+        var pathSegments = ParsePathSegments(rawPath);
+        if (TryResolvePdf(line, pathSegments, file, out var filePath) is { } error)
+        {
+            return error;
+        }
+
+        try
+        {
+            var stream = File.OpenRead(filePath!);
+            return Results.File(stream, MediaTypeNames.Application.Pdf, enableRangeProcessing: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "Failed to open PDF {File} for line {Line}", file, line);
+            return Results.Problem("ไม่สามารถเปิดไฟล์ PDF ได้ กรุณาตรวจสอบการแชร์และสิทธิ์การเข้าถึง");
+        }
+    }
+
+    internal IResult GetEditStatuses()
+    {
+        var statuses = _allowedLines
+            .OrderBy(line => line, StringComparer.OrdinalIgnoreCase)
+            .Select(BuildLineEditStatus)
+            .ToList();
+
+        return Results.Ok(statuses);
+    }
+
+    internal async Task<IResult> UploadPdfAsync(string line, HttpRequest request)
+    {
+        var pathSegments = ParsePathSegments(request.Query["path"].ToString());
+        if (!TryResolveDirectory(line, pathSegments, out var directoryPath, out _, out var pathError))
+        {
+            return pathError ?? Results.NotFound("Unknown folder");
+        }
+
+        if (!request.HasFormContentType)
+        {
+            return Results.BadRequest("ต้องเป็น multipart/form-data");
+        }
+
+        try
+        {
+            var form = await request.ReadFormAsync();
+            var formFile = form.Files.GetFile("file");
+
+            if (formFile is null || formFile.Length == 0)
+            {
+                return Results.BadRequest("ไม่พบไฟล์หรือไฟล์ว่าง");
+            }
+
+            var originalName = Path.GetFileName(formFile.FileName);
+            if (!IsValidPdfFileName(originalName))
+            {
+                return Results.BadRequest("รองรับเฉพาะไฟล์ .pdf เท่านั้น");
+            }
+
+            if (formFile.Length > _maxUploadBytes)
+            {
+                return Results.BadRequest($"ไฟล์มีขนาดเกิน {_maxUploadBytes / (1024 * 1024)} MB");
+            }
+
+            var commentRaw = form["comment"].ToString();
+            if (string.IsNullOrWhiteSpace(commentRaw))
+            {
+                return Results.BadRequest("กรุณากรอกคอมเมนต์เพื่อบันทึกการอัปเดต");
+            }
+
+            var comment = commentRaw.Trim();
+            if (comment.Length > MaxCommentLength)
+            {
+                return Results.BadRequest($"คอมเมนต์ยาวเกินไป (สูงสุด {MaxCommentLength} ตัวอักษร)");
+            }
+
+            var metadata = LoadMetadata(directoryPath!);
+            var baseName = NormalizeBaseName(Path.GetFileNameWithoutExtension(originalName));
+            var nextDivision = GetNextDivisionNumber(directoryPath!, baseName, metadata);
+            var storedFileName = $"{baseName}_Division{nextDivision:D2}.pdf";
+            var destination = Path.Combine(directoryPath!, storedFileName);
+
+            if (File.Exists(destination))
+            {
+                return Results.Conflict("ไฟล์เวอร์ชันนี้มีอยู่แล้ว");
+            }
+
+            await using var readStream = formFile.OpenReadStream();
+            await using var writeStream = new FileStream(destination, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            await readStream.CopyToAsync(writeStream);
+
+            var now = DateTime.UtcNow;
+
+            if (!metadata.Documents.TryGetValue(baseName, out var versions))
+            {
+                versions = new List<PdfVersionMetadata>();
+                metadata.Documents[baseName] = versions;
+            }
+
+            versions.RemoveAll(v => string.Equals(v.FileName, storedFileName, StringComparison.OrdinalIgnoreCase));
+            versions.Add(new PdfVersionMetadata
+            {
+                FileName = storedFileName,
+                Division = nextDivision,
+                UploadedUtc = now,
+                Comment = comment
+            });
+            versions.Sort((left, right) => left.Division.CompareTo(right.Division));
+
+            SaveMetadata(directoryPath!, metadata);
+
+            return Results.Ok(new
+            {
+                file = storedFileName,
+                baseName,
+                division = nextDivision,
+                comment,
+                uploadedUtc = now,
+                path = pathSegments
+            });
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "Failed to upload PDF to {Line}", line);
+            return Results.Problem("ไม่สามารถอัปโหลดไฟล์ได้ กรุณาตรวจสอบสิทธิ์การเข้าถึง");
+        }
+    }
+
+    internal async Task<IResult> CreateSubfolderAsync(string line, HttpContext context)
+    {
+        var pathSegments = ParsePathSegments(context.Request.Query["path"].ToString());
+        if (!TryResolveDirectory(line, pathSegments, out var directoryPath, out _, out var error))
+        {
+            return error ?? Results.NotFound("Unknown folder");
+        }
+
+        CreateFolderRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync<CreateFolderRequest>();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException or System.Text.Json.JsonException)
+        {
+            _logger.LogWarning(ex, "Invalid folder creation payload for line {Line}", line);
+            return Results.BadRequest("รูปแบบคำขอไม่ถูกต้อง");
+        }
+
+        var name = request?.Name?.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return Results.BadRequest("กรุณาระบุชื่อโฟลเดอร์");
+        }
+
+        if (!IsValidFolderName(name))
+        {
+            return Results.BadRequest("ชื่อโฟลเดอร์ไม่ถูกต้อง");
+        }
+
+        var targetPath = Path.Combine(directoryPath!, name);
+
+        if (Directory.Exists(targetPath))
+        {
+            return Results.Conflict("มีโฟลเดอร์ชื่อนี้อยู่แล้ว");
+        }
+
+        try
+        {
+            Directory.CreateDirectory(targetPath);
+            return Results.Ok(new { folder = name, path = pathSegments });
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(ex, "Failed to create subfolder {Folder} for line {Line}", name, line);
+            return Results.Problem("ไม่สามารถสร้างโฟลเดอร์ได้ กรุณาตรวจสอบสิทธิ์การเข้าถึง");
+        }
+    }
+
+    private PdfMetadata LoadMetadata(string directoryPath)
+    {
+        var metadataPath = Path.Combine(directoryPath, MetadataFileName);
+
+        if (!File.Exists(metadataPath))
+        {
+            return new PdfMetadata();
+        }
+
+        try
+        {
+            var json = File.ReadAllText(metadataPath, Encoding.UTF8);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return new PdfMetadata();
+            }
+
+            var metadata = JsonSerializer.Deserialize<PdfMetadata>(json, MetadataSerializerOptions) ?? new PdfMetadata();
+            NormalizeMetadata(metadata);
+            return metadata;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            _logger.LogWarning(ex, "Failed to load metadata for directory {Directory}", directoryPath);
+            return new PdfMetadata();
+        }
+    }
+
+    private static void NormalizeMetadata(PdfMetadata metadata)
+    {
+        if (metadata.Documents is null)
+        {
+            metadata.Documents = new Dictionary<string, List<PdfVersionMetadata>>(StringComparer.OrdinalIgnoreCase);
+            return;
+        }
+
+        if (metadata.Documents.Comparer != StringComparer.OrdinalIgnoreCase)
+        {
+            metadata.Documents = new Dictionary<string, List<PdfVersionMetadata>>(metadata.Documents, StringComparer.OrdinalIgnoreCase);
+        }
+
+        foreach (var key in metadata.Documents.Keys.ToList())
+        {
+            var versions = metadata.Documents[key] ?? new List<PdfVersionMetadata>();
+            var normalized = versions
+                .Where(v => v is not null && !string.IsNullOrWhiteSpace(v.FileName))
+                .Select(v =>
+                {
+                    v.Comment ??= string.Empty;
+                    return v;
+                })
+                .ToList();
+
+            metadata.Documents[key] = normalized;
+        }
+    }
+
+    private static bool PruneMetadata(PdfMetadata metadata, IReadOnlyCollection<string> currentFiles)
+    {
+        if (metadata.Documents.Count == 0)
+        {
+            return false;
+        }
+
+        var fileSet = new HashSet<string>(currentFiles, StringComparer.OrdinalIgnoreCase);
+        var changed = false;
+
+        foreach (var key in metadata.Documents.Keys.ToList())
+        {
+            var versions = metadata.Documents[key];
+            var filtered = versions
+                .Where(v => fileSet.Contains(v.FileName))
+                .ToList();
+
+            if (filtered.Count != versions.Count)
+            {
+                changed = true;
+                if (filtered.Count == 0)
+                {
+                    metadata.Documents.Remove(key);
+                }
+                else
+                {
+                    metadata.Documents[key] = filtered;
+                }
+            }
+        }
+
+        return changed;
+    }
+
+    private IReadOnlyList<FolderDocument> BuildDocumentListing(string directoryPath, IReadOnlyCollection<string> files, PdfMetadata metadata)
+    {
+        var documents = new Dictionary<string, List<PdfVersion>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in files)
+        {
+            string baseName;
+            PdfVersionMetadata? metadataEntry = null;
+
+            if (TryGetMetadataEntry(metadata, file, out var metadataBase, out metadataEntry))
+            {
+                baseName = NormalizeBaseName(metadataBase);
+            }
+            else if (TryParseDivisionSuffix(file, out var parsedBase, out _))
+            {
+                baseName = NormalizeBaseName(parsedBase);
+            }
+            else
+            {
+                baseName = NormalizeBaseName(Path.GetFileNameWithoutExtension(file));
+            }
+
+            var division = metadataEntry?.Division ?? 0;
+            if (division == 0 && TryParseDivisionSuffix(file, out var parsedBaseName, out var parsedDivision)
+                && string.Equals(parsedBaseName, baseName, StringComparison.OrdinalIgnoreCase))
+            {
+                division = parsedDivision;
+            }
+
+            var filePath = Path.Combine(directoryPath, file);
+            var uploadedUtc = metadataEntry?.UploadedUtc ?? GetLastWriteTimeUtcSafe(filePath);
+            var comment = metadataEntry?.Comment ?? string.Empty;
+
+            if (!documents.TryGetValue(baseName, out var versionList))
+            {
+                versionList = new List<PdfVersion>();
+                documents[baseName] = versionList;
+            }
+
+            if (versionList.Any(v => string.Equals(v.FileName, file, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            versionList.Add(new PdfVersion(file, division, uploadedUtc, comment));
+        }
+
+        foreach (var list in documents.Values)
+        {
+            list.Sort((left, right) =>
+            {
+                var divisionComparison = left.Division.CompareTo(right.Division);
+                if (divisionComparison != 0)
+                {
+                    return divisionComparison;
+                }
+
+                return string.Compare(left.FileName, right.FileName, StringComparison.OrdinalIgnoreCase);
+            });
+        }
+
+        return documents
+            .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kvp => new FolderDocument(kvp.Key, kvp.Value))
+            .ToList();
+    }
+
+    private static bool TryGetMetadataEntry(PdfMetadata metadata, string fileName, out string baseName, out PdfVersionMetadata? entry)
+    {
+        foreach (var kvp in metadata.Documents)
+        {
+            var match = kvp.Value.FirstOrDefault(v => string.Equals(v.FileName, fileName, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                baseName = kvp.Key;
+                entry = match;
+                return true;
+            }
+        }
+
+        baseName = string.Empty;
+        entry = null;
+        return false;
+    }
+
+    private void TryPersistMetadata(string directoryPath, PdfMetadata metadata)
+    {
+        try
+        {
+            SaveMetadata(directoryPath, metadata);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogWarning(ex, "Failed to persist metadata for {Directory}", directoryPath);
+        }
+    }
+
+    private void SaveMetadata(string directoryPath, PdfMetadata metadata)
+    {
+        NormalizeMetadata(metadata);
+        var metadataPath = Path.Combine(directoryPath, MetadataFileName);
+        var json = JsonSerializer.Serialize(metadata, MetadataSerializerOptions);
+        File.WriteAllText(metadataPath, json, Encoding.UTF8);
+    }
+
+    private DateTime GetLastWriteTimeUtcSafe(string fullPath)
+    {
+        try
+        {
+            return File.GetLastWriteTimeUtc(fullPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogWarning(ex, "Failed to read last write time for {File}", fullPath);
+            return DateTime.UtcNow;
+        }
+    }
+
+    private static string NormalizeBaseName(string rawBaseName)
+    {
+        if (string.IsNullOrWhiteSpace(rawBaseName))
+        {
+            return "Document";
+        }
+
+        var stripped = StripDivisionSuffix(rawBaseName.Trim());
+        return SanitizeFileNameComponent(stripped);
+    }
+
+    private static string StripDivisionSuffix(string baseName)
+    {
+        const string marker = "_Division";
+        var index = baseName.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (index >= 0)
+        {
+            var suffix = baseName[(index + marker.Length)..];
+            if (int.TryParse(suffix, out _))
+            {
+                return baseName[..index];
+            }
+        }
+
+        return baseName;
+    }
+
+    private static string SanitizeFileNameComponent(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Document";
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(value.Length);
+
+        foreach (var ch in value)
+        {
+            builder.Append(invalid.Contains(ch) ? '_' : ch);
+        }
+
+        var sanitized = builder.ToString().Trim('_', ' ');
+        return string.IsNullOrWhiteSpace(sanitized) ? "Document" : sanitized;
+    }
+
+    private static bool TryParseDivisionSuffix(string fileName, out string baseName, out int division)
+    {
+        var nameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+        const string marker = "_Division";
+        var index = nameWithoutExtension.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (index >= 0)
+        {
+            var suffix = nameWithoutExtension[(index + marker.Length)..];
+            if (int.TryParse(suffix, out var parsedDivision) && parsedDivision > 0)
+            {
+                baseName = nameWithoutExtension[..index];
+                division = parsedDivision;
+                return true;
+            }
+        }
+
+        baseName = nameWithoutExtension;
+        division = 0;
+        return false;
+    }
+
+    private int GetNextDivisionNumber(string directoryPath, string baseName, PdfMetadata metadata)
+    {
+        var maxDivision = 0;
+
+        if (metadata.Documents.TryGetValue(baseName, out var versions) && versions.Count > 0)
+        {
+            maxDivision = Math.Max(maxDivision, versions.Max(v => v.Division));
+        }
+
+        foreach (var file in Directory.EnumerateFiles(directoryPath, "*.pdf", SearchOption.TopDirectoryOnly))
+        {
+            var fileName = Path.GetFileName(file);
+            if (fileName is null)
+            {
+                continue;
+            }
+
+            if (TryParseDivisionSuffix(fileName, out var parsedBase, out var parsedDivision)
+                && string.Equals(parsedBase, baseName, StringComparison.OrdinalIgnoreCase))
+            {
+                maxDivision = Math.Max(maxDivision, parsedDivision);
+            }
+        }
+
+        return maxDivision + 1;
+    }
+
+    private bool TryResolveDirectory(string line, IReadOnlyList<string> segments, out string? directoryPath, out List<string>? normalizedSegments, out IResult? error)
+    {
+        directoryPath = null;
+        normalizedSegments = null;
+        error = null;
+
+        if (!TryResolveLine(line, out var linePath))
+        {
+            error = Results.NotFound("Unknown folder");
+            return false;
+        }
+
+        var currentDirectory = new DirectoryInfo(linePath!);
+        var collected = new List<string>();
+
+        foreach (var segment in segments)
+        {
+            if (!IsValidFolderName(segment))
+            {
+                error = Results.BadRequest("ชื่อโฟลเดอร์ไม่ถูกต้อง");
+                return false;
+            }
+
+            var nextPath = Path.Combine(currentDirectory.FullName, segment);
+            if (!Directory.Exists(nextPath))
+            {
+                error = Results.NotFound("ไม่พบโฟลเดอร์ที่ระบุ");
+                return false;
+            }
+
+            currentDirectory = new DirectoryInfo(nextPath);
+            collected.Add(currentDirectory.Name);
+        }
+
+        directoryPath = currentDirectory.FullName;
+        normalizedSegments = collected;
+        return true;
+    }
+
+    private bool TryResolveLine(string line, out string? linePath)
+    {
+        linePath = null;
+        if (!_allowedLines.Contains(line))
+        {
+            return false;
+        }
+
+        var candidate = Path.Combine(_pdfRoot, line);
+        if (!Directory.Exists(candidate))
+        {
+            return false;
+        }
+
+        linePath = candidate;
+        return true;
+    }
+
+    private IResult? TryResolvePdf(string line, IReadOnlyList<string> pathSegments, string file, out string? filePath)
+    {
+        filePath = null;
+        if (!IsValidPdfFileName(file))
+        {
+            return Results.BadRequest("Invalid PDF file name");
+        }
+
+        if (!TryResolveDirectory(line, pathSegments, out var directoryPath, out _, out var error))
+        {
+            return error;
+        }
+
+        var candidate = Path.Combine(directoryPath!, file);
+        if (!File.Exists(candidate))
+        {
+            return Results.NotFound();
+        }
+
+        filePath = candidate;
+        return null;
+    }
+
+    private static IReadOnlyList<string> ParsePathSegments(string? rawPath)
+    {
+        if (string.IsNullOrWhiteSpace(rawPath))
+        {
+            return Array.Empty<string>();
+        }
+
+        return rawPath
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static bool IsValidPdfFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return false;
+        }
+
+        if (!fileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.Equals(Path.GetFileName(fileName), fileName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return fileName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+    }
+
+    private static bool IsValidFolderName(string? folderName)
+    {
+        if (string.IsNullOrWhiteSpace(folderName))
+        {
+            return false;
+        }
+
+        var trimmed = folderName.Trim();
+        if (trimmed.Length > 100)
+        {
+            return false;
+        }
+
+        if (string.Equals(trimmed, ".", StringComparison.Ordinal) || string.Equals(trimmed, "..", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return trimmed.IndexOfAny(Path.GetInvalidFileNameChars()) < 0
+               && !trimmed.Contains(Path.DirectorySeparatorChar)
+               && !trimmed.Contains(Path.AltDirectorySeparatorChar);
+    }
+
+    private static string BuildRelativeFilePath(IReadOnlyList<string> segments, string fileName)
+    {
+        if (segments.Count == 0)
+        {
+            return fileName;
+        }
+
+        return string.Join('/', segments) + "/" + fileName;
+    }
+
+    private static string DescribeRelativeTime(DateTime timestampUtc)
+    {
+        var now = DateTime.UtcNow;
+        var delta = now - timestampUtc;
+
+        if (delta < TimeSpan.Zero)
+        {
+            delta = TimeSpan.Zero;
+        }
+
+        if (delta.TotalMinutes < 1)
+        {
+            return "เมื่อสักครู่";
+        }
+
+        if (delta.TotalHours < 1)
+        {
+            return $"ประมาณ {Math.Floor(delta.TotalMinutes)} นาทีที่แล้ว";
+        }
+
+        if (delta.TotalDays < 1)
+        {
+            return $"ประมาณ {Math.Floor(delta.TotalHours)} ชั่วโมงที่แล้ว";
+        }
+
+        if (delta.TotalDays < 7)
+        {
+            return $"ประมาณ {Math.Floor(delta.TotalDays)} วันที่แล้ว";
+        }
+
+        if (delta.TotalDays < 30)
+        {
+            return $"ประมาณ {Math.Floor(delta.TotalDays / 7)} สัปดาห์ที่แล้ว";
+        }
+
+        if (delta.TotalDays < 365)
+        {
+            return $"ประมาณ {Math.Floor(delta.TotalDays / 30)} เดือนที่แล้ว";
+        }
+
+        return $"ประมาณ {Math.Floor(delta.TotalDays / 365)} ปีที่แล้ว";
+    }
+
+    private BranchEditStatus BuildBranchStatus(DirectoryInfo directory, IReadOnlyList<string> segments)
+    {
+        List<FileInfo> pdfFiles;
+        try
+        {
+            pdfFiles = directory.EnumerateFiles("*.pdf", SearchOption.TopDirectoryOnly)
+                .Where(file => IsValidPdfFileName(file.Name))
+                .OrderByDescending(file => file.LastWriteTimeUtc)
+                .ToList();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new BranchEditStatus(
+                directory.Name,
+                segments.ToList(),
+                PdfCount: 0,
+                TotalPdfCount: 0,
+                LastModifiedUtc: null,
+                Status: "ไม่สามารถอ่านไฟล์ในกิ่งนี้ได้",
+                RecentFiles: Array.Empty<FileEditStatus>(),
+                Documents: Array.Empty<DocumentEditStatus>(),
+                Children: Array.Empty<BranchEditStatus>(),
+                ErrorMessage: $"ไม่สามารถอ่านไฟล์: {ex.Message}");
+        }
+
+        var metadata = LoadMetadata(directory.FullName);
+        var fileNames = pdfFiles.Select(file => file.Name).ToList();
+        var metadataChanged = PruneMetadata(metadata, fileNames);
+
+        var documentListings = BuildDocumentListing(directory.FullName, fileNames, metadata);
+        var documentStatuses = documentListings
+            .Select(doc =>
+            {
+                var versions = doc.Versions
+                    .OrderByDescending(v => v.UploadedUtc)
+                    .ThenByDescending(v => v.Division)
+                    .Select(v => new PdfVersionStatus(
+                        v.FileName,
+                        v.Division,
+                        v.UploadedUtc,
+                        v.Comment ?? string.Empty,
+                        BuildRelativeFilePath(segments, v.FileName)))
+                    .ToList();
+
+                DateTime? latest = versions.Count > 0
+                    ? versions[0].UploadedUtc
+                    : (DateTime?)null;
+
+                return new DocumentEditStatus(doc.BaseName, latest, versions);
+            })
+            .OrderByDescending(d => d.LatestUploadedUtc ?? DateTime.MinValue)
+            .ThenBy(d => d.BaseName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (metadataChanged)
+        {
+            TryPersistMetadata(directory.FullName, metadata);
+        }
+
+        var recentFiles = pdfFiles
+            .Take(5)
+            .Select(file => new FileEditStatus(
+                file.Name,
+                file.LastWriteTimeUtc,
+                file.Length,
+                BuildRelativeFilePath(segments, file.Name)))
+            .ToList();
+
+        var children = new List<BranchEditStatus>();
+        string? childEnumerationError = null;
+
+        try
+        {
+            foreach (var childDirectory in directory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
+                         .Where(dir => IsValidFolderName(dir.Name))
+                         .OrderBy(dir => dir.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                var childSegments = new List<string>(segments) { childDirectory.Name };
+                children.Add(BuildBranchStatus(childDirectory, childSegments));
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            childEnumerationError = $"ไม่สามารถอ่านโฟลเดอร์ย่อย: {ex.Message}";
+        }
+
+        var pdfCount = pdfFiles.Count;
+        var totalPdfCount = pdfCount + children.Sum(child => child.TotalPdfCount);
+
+        DateTime? lastModified = pdfFiles.Count > 0
+            ? pdfFiles.Max(file => file.LastWriteTimeUtc)
+            : (DateTime?)null;
+
+        foreach (var child in children)
+        {
+            if (child.LastModifiedUtc is { } childLast && (lastModified is null || childLast > lastModified))
+            {
+                lastModified = childLast;
+            }
+        }
+
+        var status = !string.IsNullOrEmpty(childEnumerationError)
+            ? childEnumerationError!
+            : BuildBranchStatusMessage(lastModified, totalPdfCount, children.Count);
+
+        return new BranchEditStatus(
+            directory.Name,
+            segments.ToList(),
+            pdfCount,
+            totalPdfCount,
+            lastModified,
+            status,
+            recentFiles,
+            documentStatuses,
+            children,
+            childEnumerationError);
+    }
+
+    private static string BuildBranchStatusMessage(DateTime? lastModifiedUtc, int totalPdfCount, int childCount)
+    {
+        if (totalPdfCount == 0)
+        {
+            return childCount > 0
+                ? "ยังไม่มีไฟล์ PDF ในกิ่งนี้"
+                : "ยังไม่มีไฟล์ PDF";
+        }
+
+        if (lastModifiedUtc is null)
+        {
+            return "มีไฟล์ PDF แต่ไม่พบข้อมูลการอัปเดต";
+        }
+
+        return $"อัปเดตล่าสุด {DescribeRelativeTime(lastModifiedUtc.Value)}";
+    }
+
+    private LineEditStatus BuildLineEditStatus(string line)
+    {
+        var lineDirectory = Path.Combine(_pdfRoot, line);
+
+        if (!Directory.Exists(lineDirectory))
+        {
+            return new LineEditStatus(line, null, "ไม่พบโฟลเดอร์สำหรับไลน์นี้บนเซิร์ฟเวอร์");
+        }
+
+        try
+        {
+            var directoryInfo = new DirectoryInfo(lineDirectory);
+            var rootBranch = BuildBranchStatus(directoryInfo, Array.Empty<string>());
+            return new LineEditStatus(line, rootBranch, null);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new LineEditStatus(line, null, $"ไม่สามารถอ่านข้อมูลได้: {ex.Message}");
+        }
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -2,6 +2,6 @@
   "Logging": { "LogLevel": { "Default": "Information", "Microsoft.AspNetCore": "Warning" } },
   "AllowedHosts": "*",
   "PdfStorage": {
-    "Root": "D:\\LocalShare\\PDFs"
+    "Root": "\\\\10.192.132.91\\PdfRoot"
   }
 }


### PR DESCRIPTION
## Summary
- rank folder and document search results by how closely they match the query so exact and prefix matches surface first
- reuse the new ranking logic for result counts to keep totals aligned with the filtered view

## Testing
- not run (`dotnet` SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e35fcdd080832f91e767418ec9afdc